### PR TITLE
Fix/new container names

### DIFF
--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -558,7 +558,7 @@ def validate_backup_owner(backup_owner: str) -> str:
 def get_base_config() -> dict:
     """Get base configuration common to all services."""
     base_config = {
-        "TEST_PASSWORD": os.getenv('TEST_PASSWORD', 'test'),
+        "TEST_PASSWORD": "secret",
         "BACKUP_WALLET": validate_backup_owner("0x802D8097eC1D49808F3c2c866020442891adde57"),
         "STAKING_CHOICE": '1'
     }


### PR DESCRIPTION
# Fix Docker Container Name Pattern Matching

Updates container detection logic to properly handle ABCI containers with unique IDs in their names. The pattern matching now correctly identifies containers following the format `{trimmed_service_name}{unique_id}_abci_0`.

## Main Changes
- Fixed container name pattern matching using startswith() and endswith()
- Added container status reload to ensure fresh state
- Improved error logging for container status checks