### PR TITLE
 Support --attended flag

### DIFF
--- a/claim_staking_rewards.sh
+++ b/claim_staking_rewards.sh
@@ -23,43 +23,5 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
-ATTENDED_ARG=""
-
-while [[ $# -gt 0 ]]; do
-   case $1 in
-       --attended=*)
-           value="${1#*=}"
-           if [[ "$value" != "true" && "$value" != "false" ]]; then
-               echo "Error: --attended only accepts true/false values"
-               exit 1
-           fi
-           if [[ "$value" == "false" ]]; then
-               ATTENDED_ARG="--attended=false"
-           fi
-           shift
-           ;;
-       --help|-h)
-           echo "Usage: ./terminate.sh <config_path> [--attended=true|false]"
-           echo
-           echo "Arguments:"
-           echo "  <config_path>              Path to config file (required)"
-           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
-           echo "  --help,-h                 Show this help message"
-           exit 0
-           ;;
-       --*)
-           echo "Error: Unknown flag $1"
-           echo "Use --help for available options"
-           exit 1
-           ;;
-       *)
-           CONFIG_PATH="$1"
-           shift
-           ;;
-   esac
-done
-
-[[ -z "$CONFIG_PATH" ]] && { echo "Error: Config path required"; exit 1; }
-
 poetry install --only main --no-cache
-poetry run python -m operate.cli claim "$CONFIG_PATH" $ATTENDED_ARG
+poetry run python -m operate.cli claim $@

--- a/claim_staking_rewards.sh
+++ b/claim_staking_rewards.sh
@@ -23,5 +23,43 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
+ATTENDED_ARG=""
+
+while [[ $# -gt 0 ]]; do
+   case $1 in
+       --attended=*)
+           value="${1#*=}"
+           if [[ "$value" != "true" && "$value" != "false" ]]; then
+               echo "Error: --attended only accepts true/false values"
+               exit 1
+           fi
+           if [[ "$value" == "false" ]]; then
+               ATTENDED_ARG="--attended=false"
+           fi
+           shift
+           ;;
+       --help|-h)
+           echo "Usage: ./terminate.sh <config_path> [--attended=true|false]"
+           echo
+           echo "Arguments:"
+           echo "  <config_path>              Path to config file (required)"
+           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
+           echo "  --help,-h                 Show this help message"
+           exit 0
+           ;;
+       --*)
+           echo "Error: Unknown flag $1"
+           echo "Use --help for available options"
+           exit 1
+           ;;
+       *)
+           CONFIG_PATH="$1"
+           shift
+           ;;
+   esac
+done
+
+[[ -z "$CONFIG_PATH" ]] && { echo "Error: Config path required"; exit 1; }
+
 poetry install --only main --no-cache
-poetry run python -m operate.cli claim "$1"
+poetry run python -m operate.cli claim "$CONFIG_PATH" $ATTENDED_ARG

--- a/reset_password.sh
+++ b/reset_password.sh
@@ -23,41 +23,5 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
-ATTENDED_ARG=""
-
-while [[ $# -gt 0 ]]; do
-   case $1 in
-       --attended=*)
-           value="${1#*=}"
-           if [[ "$value" != "true" && "$value" != "false" ]]; then
-               echo "Error: --attended only accepts true/false values"
-               exit 1
-           fi
-           if [[ "$value" == "false" ]]; then
-               ATTENDED_ARG="--attended=false"
-           fi
-           shift
-           ;;
-       --help|-h)
-           echo "Usage: ./terminate.sh [--attended=true|false]"
-           echo
-           echo "Arguments:"
-           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
-           echo "  --help,-h                 Show this help message"
-           exit 0
-           ;;
-       --*)
-           echo "Error: Unknown flag $1"
-           echo "Use --help for available options"
-           exit 1
-           ;;
-       *)
-           echo "Error: Unknown argument $1"
-           echo "Use --help for available options"
-           exit 1
-           ;;
-   esac
-done
-
 poetry install --only main --no-cache
-poetry run python -m operate.cli reset-password $ATTENDED_ARG
+poetry run python -m operate.cli reset-password $@

--- a/reset_password.sh
+++ b/reset_password.sh
@@ -23,5 +23,41 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
+ATTENDED_ARG=""
+
+while [[ $# -gt 0 ]]; do
+   case $1 in
+       --attended=*)
+           value="${1#*=}"
+           if [[ "$value" != "true" && "$value" != "false" ]]; then
+               echo "Error: --attended only accepts true/false values"
+               exit 1
+           fi
+           if [[ "$value" == "false" ]]; then
+               ATTENDED_ARG="--attended=false"
+           fi
+           shift
+           ;;
+       --help|-h)
+           echo "Usage: ./terminate.sh [--attended=true|false]"
+           echo
+           echo "Arguments:"
+           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
+           echo "  --help,-h                 Show this help message"
+           exit 0
+           ;;
+       --*)
+           echo "Error: Unknown flag $1"
+           echo "Use --help for available options"
+           exit 1
+           ;;
+       *)
+           echo "Error: Unknown argument $1"
+           echo "Use --help for available options"
+           exit 1
+           ;;
+   esac
+done
+
 poetry install --only main --no-cache
-poetry run python -m operate.cli reset-password
+poetry run python -m operate.cli reset-password $ATTENDED_ARG

--- a/reset_staking.sh
+++ b/reset_staking.sh
@@ -23,43 +23,5 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
-ATTENDED_ARG=""
-
-while [[ $# -gt 0 ]]; do
-   case $1 in
-       --attended=*)
-          value="${1#*=}"
-          if [[ "$value" != "true" && "$value" != "false" ]]; then
-              echo "Error: --attended only accepts true/false values"
-              exit 1
-          fi
-          if [[ "$value" == "false" ]]; then
-              ATTENDED_ARG="--attended=false"
-          fi
-          shift
-          ;;
-       --help|-h)
-           echo "Usage: ./reset-staking.sh <config_path> [--attended=true|false]"
-           echo
-           echo "Arguments:"
-           echo "  <config_path>              Path to config file (required)"
-           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
-           echo "  --help,-h                 Show this help message"
-           exit 0
-           ;;
-       --*)
-           echo "Error: Unknown flag $1"
-           echo "Use --help for available options"
-           exit 1
-           ;;
-       *)
-           CONFIG_PATH="$1"
-           shift
-           ;;
-   esac
-done
-
-[[ -z "$CONFIG_PATH" ]] && { echo "Error: Config path required"; exit 1; }
-
 poetry install --only main --no-cache
-poetry run python -m operate.cli reset-staking "$CONFIG_PATH" $ATTENDED_ARG
+poetry run python -m operate.cli reset-staking $@

--- a/reset_staking.sh
+++ b/reset_staking.sh
@@ -23,5 +23,43 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
+ATTENDED_ARG=""
+
+while [[ $# -gt 0 ]]; do
+   case $1 in
+       --attended=*)
+          value="${1#*=}"
+          if [[ "$value" != "true" && "$value" != "false" ]]; then
+              echo "Error: --attended only accepts true/false values"
+              exit 1
+          fi
+          if [[ "$value" == "false" ]]; then
+              ATTENDED_ARG="--attended=false"
+          fi
+          shift
+          ;;
+       --help|-h)
+           echo "Usage: ./reset-staking.sh <config_path> [--attended=true|false]"
+           echo
+           echo "Arguments:"
+           echo "  <config_path>              Path to config file (required)"
+           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
+           echo "  --help,-h                 Show this help message"
+           exit 0
+           ;;
+       --*)
+           echo "Error: Unknown flag $1"
+           echo "Use --help for available options"
+           exit 1
+           ;;
+       *)
+           CONFIG_PATH="$1"
+           shift
+           ;;
+   esac
+done
+
+[[ -z "$CONFIG_PATH" ]] && { echo "Error: Config path required"; exit 1; }
+
 poetry install --only main --no-cache
-poetry run python -m operate.cli reset-staking "$1"
+poetry run python -m operate.cli reset-staking "$CONFIG_PATH" $ATTENDED_ARG

--- a/run_service.sh
+++ b/run_service.sh
@@ -23,45 +23,6 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
-ATTENDED_ARG=""
-
-while [[ $# -gt 0 ]]; do
-   case $1 in
-       --attended=*)
-          value="${1#*=}"
-        if [[ "$value" != "true" && "$value" != "false" ]]; then
-            echo "Error: --attended only accepts true/false values"
-            exit 1
-        fi
-        # No attended flag for true (since it's default), only add for false
-        if [[ "$value" == "false" ]]; then
-            ATTENDED_ARG="--attended=false"
-        fi
-        shift
-        ;;
-       --help|-h)
-           echo "Usage: ./run_service.sh <config_path> [--attended=true|false]"
-           echo
-           echo "Arguments:"
-           echo "  <config_path>              Path to config file (required)"
-           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
-           echo "  --help,-h                 Show this help message"
-           exit 0
-           ;;
-       --*)
-           echo "Error: Unknown flag $1"
-           echo "Use --help for available options"
-           exit 1
-           ;;
-       *)
-           CONFIG_PATH="$1"
-           shift
-           ;;
-   esac
-done
-
-[[ -z "$CONFIG_PATH" ]] && { echo "Error: Config path required"; exit 1; }
-
 # Display information of the Git repository
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 latest_commit_hash=$(git rev-parse HEAD)
@@ -108,4 +69,4 @@ docker rm -f abci0 node0 trader_abci_0 trader_tm_0 &> /dev/null ||
 
 # Install dependencies and run the agent througth the middleware
 poetry install --only main --no-cache
-poetry run python -m operate.cli quickstart "$CONFIG_PATH" $ATTENDED_ARG
+poetry run python -m operate.cli quickstart $@

--- a/terminate_on_chain_service.sh
+++ b/terminate_on_chain_service.sh
@@ -24,5 +24,43 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
+ATTENDED_ARG=""
+
+while [[ $# -gt 0 ]]; do
+   case $1 in
+       --attended=*)
+           value="${1#*=}"
+           if [[ "$value" != "true" && "$value" != "false" ]]; then
+               echo "Error: --attended only accepts true/false values"
+               exit 1
+           fi
+           if [[ "$value" == "false" ]]; then
+               ATTENDED_ARG="--attended=false"
+           fi
+           shift
+           ;;
+       --help|-h)
+           echo "Usage: ./terminate.sh <config_path> [--attended=true|false]"
+           echo
+           echo "Arguments:"
+           echo "  <config_path>              Path to config file (required)"
+           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
+           echo "  --help,-h                 Show this help message"
+           exit 0
+           ;;
+       --*)
+           echo "Error: Unknown flag $1"
+           echo "Use --help for available options"
+           exit 1
+           ;;
+       *)
+           CONFIG_PATH="$1"
+           shift
+           ;;
+   esac
+done
+
+[[ -z "$CONFIG_PATH" ]] && { echo "Error: Config path required"; exit 1; }
+
 poetry install --only main --no-cache
-poetry run python -m operate.cli terminate "$1"
+poetry run python -m operate.cli terminate "$CONFIG_PATH" $ATTENDED_ARG

--- a/terminate_on_chain_service.sh
+++ b/terminate_on_chain_service.sh
@@ -24,43 +24,5 @@ export PYTHONUTF8=1
 
 set -e  # Exit script on first error
 
-ATTENDED_ARG=""
-
-while [[ $# -gt 0 ]]; do
-   case $1 in
-       --attended=*)
-           value="${1#*=}"
-           if [[ "$value" != "true" && "$value" != "false" ]]; then
-               echo "Error: --attended only accepts true/false values"
-               exit 1
-           fi
-           if [[ "$value" == "false" ]]; then
-               ATTENDED_ARG="--attended=false"
-           fi
-           shift
-           ;;
-       --help|-h)
-           echo "Usage: ./terminate.sh <config_path> [--attended=true|false]"
-           echo
-           echo "Arguments:"
-           echo "  <config_path>              Path to config file (required)"
-           echo "  --attended=true|false      Run in attended/unattended mode (default: true)"
-           echo "  --help,-h                 Show this help message"
-           exit 0
-           ;;
-       --*)
-           echo "Error: Unknown flag $1"
-           echo "Use --help for available options"
-           exit 1
-           ;;
-       *)
-           CONFIG_PATH="$1"
-           shift
-           ;;
-   esac
-done
-
-[[ -z "$CONFIG_PATH" ]] && { echo "Error: Config path required"; exit 1; }
-
 poetry install --only main --no-cache
-poetry run python -m operate.cli terminate "$CONFIG_PATH" $ATTENDED_ARG
+poetry run python -m operate.cli terminate $@


### PR DESCRIPTION
PR Title: Add --attended flag support to service management scripts

Description:
This PR adds support for attended/unattended mode execution in our service management shell scripts (run_service.sh and terminate.sh). This flag allows for more flexible automation and interactive control.

Changes:
- Added `--attended` flag support to both scripts with true/false options (default: true)
- Added argument validation for the `--attended` flag values
- Updated help messages to document the new flag
- Modified Python CLI calls to pass through the attended flag when specified as false
- Maintained backward compatibility with default attended mode

Example usage:
```bash
# Run in default attended mode
./run_service.sh config.json

# Run in unattended mode
./run_service.sh config.json --attended=false
```

Note: This change enables better automation support while maintaining the interactive mode as default for backward compatibility.