### PR TITLE
Chore: Bump middleware to `v0.3.0`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2254,13 +2254,13 @@ nicer-shell = ["ipython"]
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.2.6"
+version = "0.3.0"
 description = ""
 optional = false
 python-versions = "<3.12,>=3.9"
 files = [
-    {file = "olas_operate_middleware-0.2.6-py3-none-any.whl", hash = "sha256:7540018297b8a075b0b4852ac75dc791a13fadcf8d9ed463d0135ee696f6e961"},
-    {file = "olas_operate_middleware-0.2.6.tar.gz", hash = "sha256:babebc932dd081422d0c9ca70c59535fdfb19da117bc3cf20057ea548a62f52b"},
+    {file = "olas_operate_middleware-0.3.0-py3-none-any.whl", hash = "sha256:7a22d0dc757254d8961afc2fb5e5d26cba02eaba24fd186b662ef805dbd09e20"},
+    {file = "olas_operate_middleware-0.3.0.tar.gz", hash = "sha256:14f2e19793c281db2eee6470fc98c69e7ae2d674decc0cf2fd01d1c0e8baefc0"},
 ]
 
 [package.dependencies]
@@ -4004,4 +4004,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "6966da113812877b60d82fe6a44a3c654508b57a85c869ad39d3ac43b768c01e"
+content-hash = "70c82b7fef2e2502b20bd6ff7806114f46773720c2b7cacb7de535bd6604475b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = []
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.12"
-olas-operate-middleware = "0.2.6"
+olas-operate-middleware = "0.3.0"
 tqdm = "^4.67.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- [x] Add supply/demand staking contracts for Mech
- [x] Fix bug reported by Zohan: Check claimable rewards before QS claim
- [x] Fix bug reported by David G: Update service when switching to/from `no_staking`

### ⚠️ Breaking Change
- [x] Change field name `service_path` to `package_path` on `config.json`.

Once the `.operate` folder is opened with this version of the middleware it will no longer be compatible with a previous version. 