### PR TITLE
Fix: Mech calls threshold in trader report

### DIFF
--- a/scripts/predict_trader/report.py
+++ b/scripts/predict_trader/report.py
@@ -373,15 +373,19 @@ if __name__ == "__main__":
             liveness_ratio = (
                 activity_checker_contract.functions.livenessRatio().call(block_identifier=current_block_number)
             )
+            current_timestamp = w3.eth.get_block(current_block_number).timestamp
+            last_ts_checkpoint = staking_token_contract.functions.tsCheckpoint().call(block_identifier=current_block_number)
+            liveness_period = (
+                staking_token_contract.functions.livenessPeriod().call(block_identifier=current_block_number)
+            )
             mech_requests_24h_threshold = math.ceil(
-                (liveness_ratio * 60 * 60 * 24) / 10**18
+                max(liveness_period, (current_timestamp - last_ts_checkpoint))
+                * liveness_ratio
+                / 10 ** 18
             )
 
             next_checkpoint_ts = (
                 staking_token_contract.functions.getNextRewardCheckpointTimestamp().call(block_identifier=current_block_number)
-            )
-            liveness_period = (
-                staking_token_contract.functions.livenessPeriod().call(block_identifier=current_block_number)
             )
             last_checkpoint_ts = next_checkpoint_ts - liveness_period
 


### PR DESCRIPTION
If the current epoch goes for a little longer than 24 hours, the mech threshold increases in proportion to the extra duration of epoch (for example 43 instead of 40). This PR updates the reporting script to reflect that change in the mech calls threshold.