### PR TITLE
hotfix: ci

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -111,6 +111,7 @@ jobs:
         python -m pip install --upgrade pip
         poetry env use python3.10
         poetry install --no-interaction
+        poetry run pip install --upgrade packaging  # TODO: update packaging version from open-aea
 
     - name: Run test
       run: poetry run pytest -v tests/test_run_service.py -s --log-cli-level=INFO -k ${{ matrix.agent }}
@@ -176,6 +177,7 @@ jobs:
         python -m pip install --upgrade pip
         poetry env use python3.10
         poetry install --no-interaction
+        poetry run pip install --upgrade packaging  # TODO: update packaging version from open-aea
 
     - name: Run test
       run: poetry run pytest -v tests/test_staking_service.py -s --log-cli-level=INFO

--- a/run_service.sh
+++ b/run_service.sh
@@ -89,4 +89,5 @@ fi
 
 # Install dependencies and run the agent througth the middleware
 poetry install --only main --no-cache
+poetry run pip install --upgrade packaging  # TODO: update packaging version from open-aea
 poetry run python -m operate.cli quickstart $@


### PR DESCRIPTION
Temporary fix to install latest version of `packaging`. A proper fix is needed to do in `open-aea`, then remove this temporary one.

The CI starts to work in the PRs that are made on top of this PRs commit. For example [this temporary PR](https://github.com/valory-xyz/quickstart/pull/108) to test this fix.