### PR TITLE
Bump the trader service to `v0.27.2`

### DIFF
--- a/configs/config_predict_trader.json
+++ b/configs/config_predict_trader.json
@@ -1,9 +1,9 @@
 {
     "name": "Trader Agent",
-    "hash": "bafybeigwo7k53ayyblcx7yvwe2yfpndq763fm3cko62qkstok3ogskdoj4",
+    "hash": "bafybeig7ljclqteme5yi5vigumk62o3wyartxvwu3rhw3pl46selr6fl5y",
     "description": "Trader agent for omen prediction markets",
     "image": "https://operate.olas.network/_next/image?url=%2Fimages%2Fprediction-agent.png&w=3840&q=75",
-    "service_version": "v0.27.0",
+    "service_version": "v0.27.2",
     "home_chain": "gnosis",
     "configurations": {
         "gnosis": {


### PR DESCRIPTION
This PR updates the QS trader agent hash to version [v0.27.2](https://github.com/valory-xyz/trader/pull/608)

This version brings an important fix for redeeming functionality on the trader side. 

