### PR TITLE
[DO NOT MERGE] Add RANDOMNESS_API_URL to config_predict_trader

### DIFF
--- a/configs/config_predict_trader.json
+++ b/configs/config_predict_trader.json
@@ -20,6 +20,12 @@
         }
     },
     "env_variables": {
+        "RANDOMNESS_API_URL": {
+            "name": "Randomness URL",
+            "description": "Drand endpoint",
+            "value": "https://api.drand.sh/public/latest",
+            "provision_type": "fixed"
+        },
         "GNOSIS_LEDGER_RPC": {
             "name": "Gnosis ledger RPC",
             "description": "",


### PR DESCRIPTION
Added RANDOMNESS_API_URL to environment variables (DRAND default endpoint is flaky)