### PR TITLE
fix: ignored malformed mech on omenstrat

### DIFF
--- a/configs/config_predict_trader.json
+++ b/configs/config_predict_trader.json
@@ -201,6 +201,12 @@
             "description": "The penalization window for an unresponsive mech in seconds.",
             "value": "7200",
             "provision_type": "fixed"
+        },
+        "IGNORED_MECHS": {
+            "name": "Ignored mechs",
+            "description": "The list of ignored mechs. The agent will ignore these mechs when using the mech marketplace.",
+            "value": "[\"0x33ca1e117c4254b2ee8cd7ef1621739431a37396\"]",
+            "provision_type": "fixed"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add mech `0x33ca1e117c4254b2ee8cd7ef1621739431a37396` to `ignored_mechs` 
- This mech's tools manifest on IPFS (`f017012203085e87c3232820023d7971e2b16c02c351d96435997766611dabc17afd050f0`) returns a corrupt PBNode (`protobuf: (PBNode) invalid wireType, expected 2, got 3`), causing `mech_information_round` to fail the whole batch after retries exhaust, emit `Event.NONE`, and loop back through `mech_version_detection_round` indefinitely

## Test plan
- [ ] Agent no longer loops between `mech_version_detection_round` and `mech_information_round`
- [ ] `mech_information_round` completes successfully with the remaining mechs