### PR TITLE
chore: update README and add extract_private_keys script for EOA access

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,12 @@ You can gain access to the assets of your AI agent as follows:
 
 Now, you have full access through the hot wallet to the Master EOA and you can transfer their assets to any other address. You can also manage the assets of the Master Safe through the DApp https://app.safe.global/, using the address located in the file `.operate/wallets/ethereum.json`.
 
-To access the Agent instance EOA account, you can import it into your hot wallet in a similar way, using the private keys found in the files in `.operate/keys`. This time you'll need to open the Accounts drop-down in Metamask &#8594; select "Add account or hardware wallet" &#8594; "Private Key" &#8594; "Select Type: Private Key", then open those `.operate/keys` files with a text editor, copy the private key, and paste it into the Metamask private key text field. Then you can manage the AI agent's assets in the AI agent Safe through the DApp https://app.safe.global/, using the address located in the file `.operate/services/sc-.../config.json` against the `"multisig"` field.
+To access the Agent instance EOA account, first run the following script:
+```bash
+./extract_private_keys.sh
+```
+Then check in `.operate/keys`, and identify which of the addresses is your agent's EOA signer. Its private key will be `<address>.pk`.
+Then you may import it into your hot wallet in the same way, using the private key files found in `.operate/keys` that ends with `.pk`. After importing, you can manage the AI agent's assets in the AI agent Safe through the DApp https://app.safe.global/, using the address located in the file `.operate/services/sc-.../config.json` against the `"multisig"` field.
 
 ## Terminate your on-chain AI agent
 

--- a/extract_private_keys.sh
+++ b/extract_private_keys.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+set -euo pipefail
+
+KEYS_DIR=".operate/keys"
+
+if ! [ -d "$KEYS_DIR" ]; then
+    echo "Directory not found: $KEYS_DIR" >&2
+    exit 1
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_CMD="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
+else
+    echo "Python is required to parse JSON files." >&2
+    exit 1
+fi
+
+processed=0
+
+for key_file in "$KEYS_DIR"/0x*; do
+    [ -e "$key_file" ] || continue
+    [ -f "$key_file" ] || continue
+
+    file_name="$(basename "$key_file")"
+
+    # Only process names that start with 0x and contain no dot.
+    if [[ "$file_name" == *.* ]]; then
+        continue
+    fi
+
+    private_key="$($PYTHON_CMD - "$key_file" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+with path.open("r", encoding="utf-8") as f:
+    data = json.load(f)
+
+private_key = data.get("private_key")
+if not isinstance(private_key, str) or private_key == "":
+    raise ValueError("missing or invalid 'private_key' field")
+
+print(private_key)
+PY
+    )" || {
+        echo "Skipping invalid key file: $key_file" >&2
+        continue
+    }
+
+    printf '%s\n' "$private_key" > "$key_file.pk"
+    processed=$((processed + 1))
+done
+
+echo "Wrote .pk files for $processed key file(s)."


### PR DESCRIPTION
This pull request improves the process for accessing your AI agent's EOA (Externally Owned Account) private keys by introducing a new helper script and updating the documentation to reflect this streamlined workflow.

**Key improvements:**

### Usability improvements

* Added a new script, `extract_private_keys.sh`, which automates the extraction of private keys from JSON key files in `.operate/keys`, outputting them as `<address>.pk` files for easy import into wallet applications.
* Updated the `README.md` instructions to guide users to run the new script before importing private keys into their wallet, making the process clearer and less error-prone.