### PR TITLE
chore: update discontinuation date in README to 4 May 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 > [!IMPORTANT]
-> **Quickstart is being discontinued on 1 May 2026.**
+> **Quickstart is being discontinued on 4 May 2026.**
 >
 > We are moving to [Pearl](https://pearl.you) as the primary way to run agents on Olas. Pearl supports all the same agents and now also runs on Raspberry Pi.
 >
-> If you are currently running agents on Quickstart, please complete the following steps before 1 May 2026:
+> If you are currently running agents on Quickstart, please complete the following steps before 4 May 2026:
 >
 > 1. Stop your running agents
 > 2. Withdraw your funds from Quickstart


### PR DESCRIPTION
This pull request updates the deprecation date for Quickstart in the `README.md` file to provide users with the correct timeline for migration.

Documentation update:

* Changed the Quickstart discontinuation date from "1 May 2026" to "4 May 2026" in the notice and migration instructions to reflect the new timeline.