### PR TITLE
feat: migrate_to_pearl.py — single-command quickstart -> Pearl migration

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -191,6 +191,143 @@ jobs:
           docker logs $container
         done
 
+  changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      migration: ${{ steps.filter.outputs.migration }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need history so the base..head diff resolves on PRs
+      - id: filter
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Always run on manual dispatch.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "migration=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Only `pull_request` provides usable BASE/HEAD SHAs. If anyone
+          # adds a `push:` (or other) trigger later, fail loudly rather
+          # than silently misfiring against empty SHAs.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "::error::changes filter doesn't support event '$EVENT'; add an explicit branch."
+            exit 1
+          fi
+          if [ -z "$BASE_SHA" ] || [ -z "$HEAD_SHA" ]; then
+            echo "::error::missing BASE_SHA/HEAD_SHA on pull_request event."
+            exit 1
+          fi
+
+          # Only run the e2e migration job when files that affect it
+          # actually change. poetry.lock is the authoritative pin for the
+          # middleware version (and everything else); any version bump
+          # lands there even if pyproject.toml is also touched.
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qE \
+            '^(migrate_to_pearl\.sh$|scripts/pearl_migration/|tests/test_migrate_to_pearl\.py$|poetry\.lock$|\.github/workflows/python-tests\.yml$)'; then
+            echo "migration=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "migration=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  e2e-test-migrate-to-pearl:
+    needs: changes
+    if: needs.changes.outputs.migration == 'true'
+    runs-on: ubuntu-24.04
+    env:
+      GNOSIS_RPC: ${{ secrets.GNOSIS_RPC }}
+      MODE_RPC: ${{ secrets.MODE_RPC }}
+      OPTIMISM_RPC: ${{ secrets.OPTIMISM_RPC }}
+      BASE_RPC: ${{ secrets.BASE_RPC }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker
+      run: |
+        sudo systemctl stop docker || true
+        sudo systemctl stop docker.socket || true
+        sudo apt-get remove -y docker docker-engine docker.io containerd runc
+        sudo apt-get update
+        sudo apt-get install -y \
+          apt-transport-https \
+          ca-certificates \
+          curl \
+          gnupg \
+          lsb-release jq
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+          $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt-get update
+        sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+        sudo systemctl start docker
+
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git
+
+    - name: Clean Python cache
+      run: |
+        sudo rm -rf ~/.cache/pip
+        sudo rm -rf ~/.cache/poetry
+        sudo rm -rf .pytest_cache
+        sudo rm -rf .venv
+        sudo rm -rf poetry.lock
+
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+
+    - name: Configure Poetry
+      run: |
+        poetry config virtualenvs.create true
+        poetry config virtualenvs.in-project true
+
+    - name: Create .env file
+      run: |
+        echo "GNOSIS_RPC=${GNOSIS_RPC}" > .env
+        echo "MODE_RPC=${MODE_RPC}" >> .env
+        echo "OPTIMISM_RPC=${OPTIMISM_RPC}" >> .env
+        echo "BASE_RPC=${BASE_RPC}" >> .env
+        echo "TEST_PASSWORD=${TEST_PASSWORD}" >> .env
+
+    - name: Install project dependencies
+      run: |
+        python -m pip install --upgrade pip
+        poetry env use python3.14
+        poetry install --no-interaction
+        poetry run pip install --upgrade packaging  # TODO: update packaging version from open-aea
+
+    - name: Run test
+      # 90 minutes: deploys 4 services across 2 quickstarts, runs 2 migrations
+      # (Mode A then Mode B with on-chain transfers + drains), then redeploys
+      # all 4 from the merged Pearl `.operate` to verify they start.
+      timeout-minutes: 90
+      run: PYTHONPATH=tests:. poetry run pytest -v tests/test_migrate_to_pearl.py -s --log-cli-level=INFO
+
+    - name: Debug container failure
+      if: failure()
+      run: |
+        docker ps -a
+        for container in $(docker ps -aq); do
+          echo "=== Logs for $container ==="
+          docker logs $container
+        done
+
   unit-tests:
     runs-on: ubuntu-24.04
     strategy:
@@ -241,6 +378,7 @@ jobs:
         PYTHONPATH=. poetry run pytest -v tests \
           --ignore=tests/test_run_service.py \
           --ignore=tests/test_staking_service.py \
+          --ignore=tests/test_migrate_to_pearl.py \
           --cov=scripts \
           --cov-fail-under=100 \
           --cov-report=term-missing \

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -56,7 +56,6 @@ jobs:
 
   e2e-test-run-service:
     needs: setup
-    if: false  # TEMP: disabled to iterate on e2e-test-migrate-to-pearl; re-enable before merge
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -127,7 +126,6 @@ jobs:
         done
 
   e2e-test-staking:
-    if: false  # TEMP: disabled to iterate on e2e-test-migrate-to-pearl; re-enable before merge
     runs-on: ubuntu-24.04
     env:
       GNOSIS_RPC: ${{ secrets.GNOSIS_RPC }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -56,6 +56,7 @@ jobs:
 
   e2e-test-run-service:
     needs: setup
+    if: false  # TEMP: disabled to iterate on e2e-test-migrate-to-pearl; re-enable before merge
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -126,6 +127,7 @@ jobs:
         done
 
   e2e-test-staking:
+    if: false  # TEMP: disabled to iterate on e2e-test-migrate-to-pearl; re-enable before merge
     runs-on: ubuntu-24.04
     env:
       GNOSIS_RPC: ${{ secrets.GNOSIS_RPC }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 >
 > We are moving to [Pearl](https://pearl.you) as the primary way to run agents on Olas. Pearl supports all the same agents and now also runs on Raspberry Pi.
 >
-> If you are currently running agents on Quickstart, please complete the following steps before 4 May 2026:
+> **The fastest way to migrate is `./migrate_to_pearl.sh`** — it carries your existing service(s), agent keys, master wallet, and on-chain state straight into Pearl's `~/.operate/` so you don't lose your service NFT, your agent's history, or your remaining funds. See [Migrate to Pearl](#migrate-to-pearl) below.
+>
+> If you'd rather migrate manually, the long way is:
 >
 > 1. Stop your running agents
 > 2. Withdraw your funds from Quickstart
@@ -14,6 +16,55 @@
 # Olas AI agents - Quickstart
 
 A quickstart to run Olas AI agents
+
+## Migrate to Pearl
+
+`./migrate_to_pearl.sh` moves your quickstart-managed service(s) into Pearl's `~/.operate/` so Pearl can pick up where Quickstart left off — same on-chain service NFT, same agent EOAs, same persistent runtime state, same remaining funds.
+
+### Usage
+
+```bash
+chmod +x migrate_to_pearl.sh
+
+# Migrate everything in this quickstart's `.operate/`. If only one service
+# is present it's auto-selected; otherwise you'll be asked to pick one or all.
+./migrate_to_pearl.sh
+
+# Or restrict to a single service config (same arg shape as run_service.sh):
+./migrate_to_pearl.sh configs/config_predict_trader.json
+
+# Useful flags:
+./migrate_to_pearl.sh --dry-run                   # discover only, no changes
+./migrate_to_pearl.sh --pearl-home /custom/path   # override the target home
+./migrate_to_pearl.sh --quickstart-home ./.operate
+./migrate_to_pearl.sh --help
+```
+
+### What it does
+
+The script auto-detects which of two modes applies:
+
+- **Fresh copy** — Pearl's `~/.operate/` does not exist (or has no master wallet yet). The whole `.operate/` directory is copied over. Pearl uses your existing master wallet on first launch — same password, same Safes.
+- **Merge** — Pearl already has its own master wallet. Per service it stops the deployment, unstakes/terminates on-chain, transfers the **service NFT** from your quickstart master Safe to Pearl's master Safe, swaps the **service Safe owner** to Pearl's master Safe, then copies the service files. Once all services succeed it drains your quickstart **master Safe + EOA** balances into Pearl's master Safe + EOA per chain.
+
+If any service can't be unstaked yet (e.g. minimum staking duration not elapsed), that service is skipped with a clear message and the master-wallet drains are skipped too — funds stay available for a follow-up run.
+
+### Requirements
+
+Same as `run_service.sh`: Python `>=3.10,<3.15`, Poetry, Docker. The script must be able to talk to the chain RPCs configured for each migrated service. Pearl must **not** be running (the script will refuse if it detects Pearl's daemon on `127.0.0.1:8765`).
+
+### Re-runs and rollback
+
+The script is safe to re-run. Every step checks the actual source of truth before acting (on-chain ownership, Safe owners, balances, file existence), so a re-run after a partial failure resumes from the first incomplete step rather than redoing everything. On collision (e.g. you're retrying a previous migration that already wrote some files), you're prompted to **skip** or **overwrite-with-backup** (`*.bak.<timestamp>`).
+
+After a successful merge, the script offers to rename your source `.operate/` to `.operate.migrated.<timestamp>` so a re-run won't pick it up but the data is preserved as a rollback. Nothing is deleted.
+
+### After migration
+
+The script ends with a yes/no question:
+
+- **"different machine"** → it tells you to copy `~/.operate/` to `~/.operate` on the destination machine. Pearl's bundled middleware will auto-migrate any schema differences on first launch.
+- **"same machine"** → just start Pearl and enter your master password. Your migrated services appear in the dashboard.
 
 ## Compatible Systems
 

--- a/migrate_to_pearl.sh
+++ b/migrate_to_pearl.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+# Migrate this quickstart's `.operate/` to Pearl's `~/.operate/`.
+# Pass --help for full usage. Optionally pass a configs/<agent>.json to
+# restrict the migration to a single service.
+
+# force utf mode for python, cause sometimes there are issues with local codepages
+export PYTHONUTF8=1
+
+set -euo pipefail   # exit on error / undefined var / pipeline failure
+
+# Tooling pre-checks — the script signs on-chain transactions, so failing
+# fast on a missing prerequisite is much better than a half-applied poetry
+# install or a confusing import error halfway through.
+if ! command -v poetry >/dev/null 2>&1; then
+    echo >&2 "Poetry is not installed (https://python-poetry.org/docs/)."
+    exit 1
+fi
+
+poetry install --only main --no-cache
+poetry run python -m scripts.pearl_migration.migrate_to_pearl "$@"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1115,123 +1115,193 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "cytoolz"
-version = "0.12.3"
+version = "1.1.0"
 description = "Cython implementation of Toolz: High performance functional utilities"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "cytoolz-0.12.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bbe58e26c84b163beba0fbeacf6b065feabc8f75c6d3fe305550d33f24a2d346"},
-    {file = "cytoolz-0.12.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c51b66ada9bfdb88cf711bf350fcc46f82b83a4683cf2413e633c31a64df6201"},
-    {file = "cytoolz-0.12.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e70d9c615e5c9dc10d279d1e32e846085fe1fd6f08d623ddd059a92861f4e3dd"},
-    {file = "cytoolz-0.12.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a83f4532707963ae1a5108e51fdfe1278cc8724e3301fee48b9e73e1316de64f"},
-    {file = "cytoolz-0.12.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d028044524ee2e815f36210a793c414551b689d4f4eda28f8bbb0883ad78bf5f"},
-    {file = "cytoolz-0.12.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c2875bcd1397d0627a09a4f9172fa513185ad302c63758efc15b8eb33cc2a98"},
-    {file = "cytoolz-0.12.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:131ff4820e5d64a25d7ad3c3556f2d8aa65c66b3f021b03f8a8e98e4180dd808"},
-    {file = "cytoolz-0.12.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:04afa90d9d9d18394c40d9bed48c51433d08b57c042e0e50c8c0f9799735dcbd"},
-    {file = "cytoolz-0.12.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:dc1ca9c610425f9854323669a671fc163300b873731584e258975adf50931164"},
-    {file = "cytoolz-0.12.3-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:bfa3f8e01bc423a933f2e1c510cbb0632c6787865b5242857cc955cae220d1bf"},
-    {file = "cytoolz-0.12.3-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:f702e295dddef5f8af4a456db93f114539b8dc2a7a9bc4de7c7e41d169aa6ec3"},
-    {file = "cytoolz-0.12.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0fbad1fb9bb47e827d00e01992a099b0ba79facf5e5aa453be066033232ac4b5"},
-    {file = "cytoolz-0.12.3-cp310-cp310-win32.whl", hash = "sha256:8587c3c3dbe78af90c5025288766ac10dc2240c1e76eb0a93a4e244c265ccefd"},
-    {file = "cytoolz-0.12.3-cp310-cp310-win_amd64.whl", hash = "sha256:9e45803d9e75ef90a2f859ef8f7f77614730f4a8ce1b9244375734567299d239"},
-    {file = "cytoolz-0.12.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3ac4f2fb38bbc67ff1875b7d2f0f162a247f43bd28eb7c9d15e6175a982e558d"},
-    {file = "cytoolz-0.12.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cf1e1e96dd86829a0539baf514a9c8473a58fbb415f92401a68e8e52a34ecd5"},
-    {file = "cytoolz-0.12.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08a438701c6141dd34eaf92e9e9a1f66e23a22f7840ef8a371eba274477de85d"},
-    {file = "cytoolz-0.12.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c6b6f11b0d7ed91be53166aeef2a23a799e636625675bb30818f47f41ad31821"},
-    {file = "cytoolz-0.12.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7fde09384d23048a7b4ac889063761e44b89a0b64015393e2d1d21d5c1f534a"},
-    {file = "cytoolz-0.12.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d3bfe45173cc8e6c76206be3a916d8bfd2214fb2965563e288088012f1dabfc"},
-    {file = "cytoolz-0.12.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:27513a5d5b6624372d63313574381d3217a66e7a2626b056c695179623a5cb1a"},
-    {file = "cytoolz-0.12.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d294e5e81ff094fe920fd545052ff30838ea49f9e91227a55ecd9f3ca19774a0"},
-    {file = "cytoolz-0.12.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:727b01a2004ddb513496507a695e19b5c0cfebcdfcc68349d3efd92a1c297bf4"},
-    {file = "cytoolz-0.12.3-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:fe1e1779a39dbe83f13886d2b4b02f8c4b10755e3c8d9a89b630395f49f4f406"},
-    {file = "cytoolz-0.12.3-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:de74ef266e2679c3bf8b5fc20cee4fc0271ba13ae0d9097b1491c7a9bcadb389"},
-    {file = "cytoolz-0.12.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9e04d22049233394e0b08193aca9737200b4a2afa28659d957327aa780ddddf2"},
-    {file = "cytoolz-0.12.3-cp311-cp311-win32.whl", hash = "sha256:20d36430d8ac809186736fda735ee7d595b6242bdb35f69b598ef809ebfa5605"},
-    {file = "cytoolz-0.12.3-cp311-cp311-win_amd64.whl", hash = "sha256:780c06110f383344d537f48d9010d79fa4f75070d214fc47f389357dd4f010b6"},
-    {file = "cytoolz-0.12.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:86923d823bd19ce35805953b018d436f6b862edd6a7c8b747a13d52b39ed5716"},
-    {file = "cytoolz-0.12.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3e61acfd029bfb81c2c596249b508dfd2b4f72e31b7b53b62e5fb0507dd7293"},
-    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd728f4e6051af6af234651df49319da1d813f47894d4c3c8ab7455e01703a37"},
-    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fe8c6267caa7ec67bcc37e360f0d8a26bc3bdce510b15b97f2f2e0143bdd3673"},
-    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99462abd8323c52204a2a0ce62454ce8fa0f4e94b9af397945c12830de73f27e"},
-    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da125221b1fa25c690fcd030a54344cecec80074df018d906fc6a99f46c1e3a6"},
-    {file = "cytoolz-0.12.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c18e351956f70db9e2d04ff02f28e9a41839250d3f936a4c8a1eabd1c3094d2"},
-    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:921e6d2440ac758c4945c587b1d1d9b781b72737ac0c0ca5d5e02ca1db8bded2"},
-    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:1651a9bd591a8326329ce1d6336f3129161a36d7061a4d5ea9e5377e033364cf"},
-    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:8893223b87c2782bd59f9c4bd5c7bf733edd8728b523c93efb91d7468b486528"},
-    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:e4d2961644153c5ae186db964aa9f6109da81b12df0f1d3494b4e5cf2c332ee2"},
-    {file = "cytoolz-0.12.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:71b6eb97f6695f7ba8ce69c49b707a351c5f46fd97f5aeb5f6f2fb0d6e72b887"},
-    {file = "cytoolz-0.12.3-cp312-cp312-win32.whl", hash = "sha256:cee3de65584e915053412cd178729ff510ad5f8f585c21c5890e91028283518f"},
-    {file = "cytoolz-0.12.3-cp312-cp312-win_amd64.whl", hash = "sha256:9eef0d23035fa4dcfa21e570961e86c375153a7ee605cdd11a8b088c24f707f6"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9a38332cfad2a91e89405b7c18b3f00e2edc951c225accbc217597d3e4e9fde"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f501ae1353071fa5d6677437bbeb1aeb5622067dce0977cedc2c5ec5843b202"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:56f899758146a52e2f8cfb3fb6f4ca19c1e5814178c3d584de35f9e4d7166d91"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:800f0526adf9e53d3c6acda748f4def1f048adaa780752f154da5cf22aa488a2"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0976a3fcb81d065473173e9005848218ce03ddb2ec7d40dd6a8d2dba7f1c3ae"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c835eab01466cb67d0ce6290601ebef2d82d8d0d0a285ed0d6e46989e4a7a71a"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:4fba0616fcd487e34b8beec1ad9911d192c62e758baa12fcb44448b9b6feae22"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6f6e8207d732651e0204779e1ba5a4925c93081834570411f959b80681f8d333"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:8119bf5961091cfe644784d0bae214e273b3b3a479f93ee3baab97bbd995ccfe"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:7ad1331cb68afeec58469c31d944a2100cee14eac221553f0d5218ace1a0b25d"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:92c53d508fb8a4463acc85b322fa24734efdc66933a5c8661bdc862103a3373d"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-win32.whl", hash = "sha256:2c6dd75dae3d84fa8988861ab8b1189d2488cb8a9b8653828f9cd6126b5e7abd"},
-    {file = "cytoolz-0.12.3-cp37-cp37m-win_amd64.whl", hash = "sha256:caf07a97b5220e6334dd32c8b6d8b2bd255ca694eca5dfe914bb5b880ee66cdb"},
-    {file = "cytoolz-0.12.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ed0cfb9326747759e2ad81cb6e45f20086a273b67ac3a4c00b19efcbab007c60"},
-    {file = "cytoolz-0.12.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:96a5a0292575c3697121f97cc605baf2fd125120c7dcdf39edd1a135798482ca"},
-    {file = "cytoolz-0.12.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b76f2f50a789c44d6fd7f773ec43d2a8686781cd52236da03f7f7d7998989bee"},
-    {file = "cytoolz-0.12.3-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2905fdccacc64b4beba37f95cab9d792289c80f4d70830b70de2fc66c007ec01"},
-    {file = "cytoolz-0.12.3-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f1ebe23028eac51251f22ba01dba6587d30aa9c320372ca0c14eeab67118ec3f"},
-    {file = "cytoolz-0.12.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96c715404a3825e37fe3966fe84c5f8a1f036e7640b2a02dbed96cac0c933451"},
-    {file = "cytoolz-0.12.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9bac0adffc1b6b6a4c5f1fd1dd2161afb720bcc771a91016dc6bdba59af0a5d3"},
-    {file = "cytoolz-0.12.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:37441bf4a2a4e2e0fe9c3b0ea5e72db352f5cca03903977ffc42f6f6c5467be9"},
-    {file = "cytoolz-0.12.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f04037302049cb30033f7fa4e1d0e44afe35ed6bfcf9b380fc11f2a27d3ed697"},
-    {file = "cytoolz-0.12.3-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:f37b60e66378e7a116931d7220f5352186abfcc950d64856038aa2c01944929c"},
-    {file = "cytoolz-0.12.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:ec9be3e4b6f86ea8b294d34c990c99d2ba6c526ef1e8f46f1d52c263d4f32cd7"},
-    {file = "cytoolz-0.12.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:0e9199c9e3fbf380a92b8042c677eb9e7ed4bccb126de5e9c0d26f5888d96788"},
-    {file = "cytoolz-0.12.3-cp38-cp38-win32.whl", hash = "sha256:18cd61e078bd6bffe088e40f1ed02001387c29174750abce79499d26fa57f5eb"},
-    {file = "cytoolz-0.12.3-cp38-cp38-win_amd64.whl", hash = "sha256:765b8381d4003ceb1a07896a854eee2c31ebc950a4ae17d1e7a17c2a8feb2a68"},
-    {file = "cytoolz-0.12.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b4a52dd2a36b0a91f7aa50ca6c8509057acc481a24255f6cb07b15d339a34e0f"},
-    {file = "cytoolz-0.12.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:581f1ce479769fe7eeb9ae6d87eadb230df8c7c5fff32138162cdd99d7fb8fc3"},
-    {file = "cytoolz-0.12.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46f505d4c6eb79585c8ad0b9dc140ef30a138c880e4e3b40230d642690e36366"},
-    {file = "cytoolz-0.12.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59276021619b432a5c21c01cda8320b9cc7dbc40351ffc478b440bfccd5bbdd3"},
-    {file = "cytoolz-0.12.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e44f4c25e1e7cf6149b499c74945a14649c8866d36371a2c2d2164e4649e7755"},
-    {file = "cytoolz-0.12.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c64f8e60c1dd69e4d5e615481f2d57937746f4a6be2d0f86e9e7e3b9e2243b5e"},
-    {file = "cytoolz-0.12.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33c63186f3bf9d7ef1347bc0537bb9a0b4111a0d7d6e619623cabc18fef0dc3b"},
-    {file = "cytoolz-0.12.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:fdddb9d988405f24035234f1e8d1653ab2e48cc2404226d21b49a129aefd1d25"},
-    {file = "cytoolz-0.12.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6986632d8a969ea1e720990c818dace1a24c11015fd7c59b9fea0b65ef71f726"},
-    {file = "cytoolz-0.12.3-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:0ba1cbc4d9cd7571c917f88f4a069568e5121646eb5d82b2393b2cf84712cf2a"},
-    {file = "cytoolz-0.12.3-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:7d267ffc9a36c0a9a58c7e0adc9fa82620f22e4a72533e15dd1361f57fc9accf"},
-    {file = "cytoolz-0.12.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:95e878868a172a41fbf6c505a4b967309e6870e22adc7b1c3b19653d062711fa"},
-    {file = "cytoolz-0.12.3-cp39-cp39-win32.whl", hash = "sha256:8e21932d6d260996f7109f2a40b2586070cb0a0cf1d65781e156326d5ebcc329"},
-    {file = "cytoolz-0.12.3-cp39-cp39-win_amd64.whl", hash = "sha256:0d8edfbc694af6c9bda4db56643fb8ed3d14e47bec358c2f1417de9a12d6d1fb"},
-    {file = "cytoolz-0.12.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:55f9bd1ae6c2a27eda5abe2a0b65a83029d2385c5a1da7b8ef47af5905d7e905"},
-    {file = "cytoolz-0.12.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2d271393c378282727f1231d40391ae93b93ddc0997448acc21dd0cb6a1e56d"},
-    {file = "cytoolz-0.12.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee98968d6a66ee83a8ceabf31182189ab5d8598998c8ce69b6d5843daeb2db60"},
-    {file = "cytoolz-0.12.3-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01cfb8518828c1189200c02a5010ea404407fb18fd5589e29c126e84bbeadd36"},
-    {file = "cytoolz-0.12.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:456395d7aec01db32bf9e6db191d667347c78d8d48e77234521fa1078f60dabb"},
-    {file = "cytoolz-0.12.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:cd88028bb897fba99ddd84f253ca6bef73ecb7bdf3f3cf25bc493f8f97d3c7c5"},
-    {file = "cytoolz-0.12.3-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59b19223e7f7bd7a73ec3aa6fdfb73b579ff09c2bc0b7d26857eec2d01a58c76"},
-    {file = "cytoolz-0.12.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a79d72b08048a0980a59457c239555f111ac0c8bdc140c91a025f124104dbb4"},
-    {file = "cytoolz-0.12.3-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1dd70141b32b717696a72b8876e86bc9c6f8eff995c1808e299db3541213ff82"},
-    {file = "cytoolz-0.12.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:a1445c91009eb775d479e88954c51d0b4cf9a1e8ce3c503c2672d17252882647"},
-    {file = "cytoolz-0.12.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ca6a9a9300d5bda417d9090107c6d2b007683efc59d63cc09aca0e7930a08a85"},
-    {file = "cytoolz-0.12.3-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be6feb903d2a08a4ba2e70e950e862fd3be9be9a588b7c38cee4728150a52918"},
-    {file = "cytoolz-0.12.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92b6f43f086e5a965d33d62a145ae121b4ccb6e0789ac0acc895ce084fec8c65"},
-    {file = "cytoolz-0.12.3-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:534fa66db8564d9b13872d81d54b6b09ae592c585eb826aac235bd6f1830f8ad"},
-    {file = "cytoolz-0.12.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:fea649f979def23150680de1bd1d09682da3b54932800a0f90f29fc2a6c98ba8"},
-    {file = "cytoolz-0.12.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a447247ed312dd64e3a8d9483841ecc5338ee26d6e6fbd29cd373ed030db0240"},
-    {file = "cytoolz-0.12.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba3f843aa89f35467b38c398ae5b980a824fdbdb94065adc6ec7c47a0a22f4c7"},
-    {file = "cytoolz-0.12.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:582c22f97a380211fb36a7b65b1beeb84ea11d82015fa84b054be78580390082"},
-    {file = "cytoolz-0.12.3-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47feb089506fc66e1593cd9ade3945693a9d089a445fbe9a11385cab200b9f22"},
-    {file = "cytoolz-0.12.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ba9002d2f043943744a9dc8e50a47362bcb6e6f360dc0a1abcb19642584d87bb"},
-    {file = "cytoolz-0.12.3.tar.gz", hash = "sha256:4503dc59f4ced53a54643272c61dc305d1dbbfbd7d6bdf296948de9f34c3a282"},
+    {file = "cytoolz-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:72d7043a88ea5e61ba9d17ea0d1c1eff10f645d7edfcc4e56a31ef78be287644"},
+    {file = "cytoolz-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d759e9ed421bacfeb456d47af8d734c057b9912b5f2441f95b27ca35e5efab07"},
+    {file = "cytoolz-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fdb5be8fbcc0396141189022724155a4c1c93712ac4aef8c03829af0c2a816d7"},
+    {file = "cytoolz-1.1.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c8c0a513dc89bc05cc72893609118815bced5ef201f1a317b4cc3423b3a0e750"},
+    {file = "cytoolz-1.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce94db4f8ebe842c30c0ece42ff5de977c47859088c2c363dede5a68f6906484"},
+    {file = "cytoolz-1.1.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b622d4f54e370c853ded94a668f94fe72c6d70e06ac102f17a2746661c27ab52"},
+    {file = "cytoolz-1.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:375a65baa5a5b4ff6a0c5ff17e170cf23312e4c710755771ca966144c24216b5"},
+    {file = "cytoolz-1.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c0d51bcdb3203a062a78f66bbe33db5e3123048e24a5f0e1402422d79df8ee2d"},
+    {file = "cytoolz-1.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1010869529bb05dc9802b6d776a34ca1b6d48b9deec70ad5e2918ae175be5c2f"},
+    {file = "cytoolz-1.1.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a8f2e83295bdb33f35454d6bafcb7845b03b5881dcaed66ecbd726c7f16772"},
+    {file = "cytoolz-1.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0499c5e0a8e688ed367a2e51cc13792ae8f08226c15f7d168589fc44b9b9cada"},
+    {file = "cytoolz-1.1.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:87d44e6033d4c5e95a7d39ba59b8e105ba1c29b1ccd1d215f26477cc1d64be39"},
+    {file = "cytoolz-1.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a68cef396a7de237f7b97422a6a450dfb111722296ba217ba5b34551832f1f6e"},
+    {file = "cytoolz-1.1.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:06ad4c95b258141f138a93ebfdc1d76ac087afc1a82f1401100a1f44b44ba656"},
+    {file = "cytoolz-1.1.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ada59a4b3c59d4ac7162e0ed08667ffa78abf48e975c8a9f9d5b9bc50720f4fd"},
+    {file = "cytoolz-1.1.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:a8957bcaea1ba01327a9b219d2adb84144377684f51444253890dab500ca171f"},
+    {file = "cytoolz-1.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6d8cdc299d67eb0f3b9ecdafeeb55eb3b7b7470e2d950ac34b05ed4c7a5572b8"},
+    {file = "cytoolz-1.1.0-cp310-cp310-win32.whl", hash = "sha256:d8e08464c5cdea4f6df31e84b11ed6bfd79cedb99fbcbfdc15eb9361a6053c5a"},
+    {file = "cytoolz-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:7e49922a7ed54262d41960bf3b835a7700327bf79cff1e9bfc73d79021132ff8"},
+    {file = "cytoolz-1.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:943a662d2e72ffc4438d43ab5a1de8d852237775a423236594a3b3e381b8032c"},
+    {file = "cytoolz-1.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:dba8e5a8c6e3c789d27b0eb5e7ce5ed7d032a7a9aae17ca4ba5147b871f6e327"},
+    {file = "cytoolz-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:44b31c05addb0889167a720123b3b497b28dd86f8a0aeaf3ae4ffa11e2c85d55"},
+    {file = "cytoolz-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:653cb18c4fc5d8a8cfce2bce650aabcbe82957cd0536827367d10810566d5294"},
+    {file = "cytoolz-1.1.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:853a5b4806915020c890e1ce70cc056bbc1dd8bc44f2d74d555cccfd7aefba7d"},
+    {file = "cytoolz-1.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7b44e9de86bea013fe84fd8c399d6016bbb96c37c5290769e5c99460b9c53e5"},
+    {file = "cytoolz-1.1.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:098d628a801dc142e9740126be5624eb7aef1d732bc7a5719f60a2095547b485"},
+    {file = "cytoolz-1.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:779ee4096ed7a82cffab89372ffc339631c285079dbf33dbe7aff1f6174985df"},
+    {file = "cytoolz-1.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f2ce18dd99533d077e9712f9faa852f389f560351b1efd2f2bdb193a95eddde2"},
+    {file = "cytoolz-1.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ac266a34437812cf841cecbfe19f355ab9c3dd1ef231afc60415d40ff12a76e4"},
+    {file = "cytoolz-1.1.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1920b9b9c13d60d0bb6cd14594b3bce0870022eccb430618c37156da5f2b7a55"},
+    {file = "cytoolz-1.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47caa376dafd2bdc29f8a250acf59c810ec9105cd6f7680b9a9d070aae8490ec"},
+    {file = "cytoolz-1.1.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5ab2c97d8aaa522b038cca9187b1153347af22309e7c998b14750c6fdec7b1cb"},
+    {file = "cytoolz-1.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4bce006121b120e8b359244ee140bb0b1093908efc8b739db8dbaa3f8fb42139"},
+    {file = "cytoolz-1.1.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7fc0f1e4e9bb384d26e73c6657bbc26abdae4ff66a95933c00f3d578be89181b"},
+    {file = "cytoolz-1.1.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:dd3f894ff972da1994d06ac6157d74e40dda19eb31fe5e9b7863ca4278c3a167"},
+    {file = "cytoolz-1.1.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:0846f49cf8a4496bd42659040e68bd0484ce6af819709cae234938e039203ba0"},
+    {file = "cytoolz-1.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:16a3af394ade1973226d64bb2f9eb3336adbdea03ed5b134c1bbec5a3b20028e"},
+    {file = "cytoolz-1.1.0-cp311-cp311-win32.whl", hash = "sha256:b786c9c8aeab76cc2f76011e986f7321a23a56d985b77d14f155d5e5514ea781"},
+    {file = "cytoolz-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:ebf06d1c5344fb22fee71bf664234733e55db72d74988f2ecb7294b05e4db30c"},
+    {file = "cytoolz-1.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:b63f5f025fac893393b186e132e3e242de8ee7265d0cd3f5bdd4dda93f6616c9"},
+    {file = "cytoolz-1.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:99f8e134c9be11649342853ec8c90837af4089fc8ff1e8f9a024a57d1fa08514"},
+    {file = "cytoolz-1.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a6f44cf9319c30feb9a50aa513d777ef51efec16f31c404409e7deb8063df64"},
+    {file = "cytoolz-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:945580dc158c557172fca899a35a99a16fbcebf6db0c77cb6621084bc82189f9"},
+    {file = "cytoolz-1.1.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:257905ec050d04f2f856854620d1e25556fd735064cebd81b460f54939b9f9d5"},
+    {file = "cytoolz-1.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82779049f352fb3ab5e8c993ab45edbb6e02efb1f17f0b50f4972c706cc51d76"},
+    {file = "cytoolz-1.1.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7d3e405e435320e08c5a1633afaf285a392e2d9cef35c925d91e2a31dfd7a688"},
+    {file = "cytoolz-1.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:923df8f5591e0d20543060c29909c149ab1963a7267037b39eee03a83dbc50a8"},
+    {file = "cytoolz-1.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:25db9e4862f22ea0ae2e56c8bec9fc9fd756b655ae13e8c7b5625d7ed1c582d4"},
+    {file = "cytoolz-1.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7a98deb11ccd8e5d9f9441ef2ff3352aab52226a2b7d04756caaa53cd612363"},
+    {file = "cytoolz-1.1.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dce4ee9fc99104bc77efdea80f32ca5a650cd653bcc8a1d984a931153d3d9b58"},
+    {file = "cytoolz-1.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80d6da158f7d20c15819701bbda1c041f0944ede2f564f5c739b1bc80a9ffb8b"},
+    {file = "cytoolz-1.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:3b5c5a192abda123ad45ef716ec9082b4cf7d95e9ada8291c5c2cc5558be858b"},
+    {file = "cytoolz-1.1.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5b399ce7d967b1cb6280250818b786be652aa8ddffd3c0bb5c48c6220d945ab5"},
+    {file = "cytoolz-1.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e7e29a1a03f00b4322196cfe8e2c38da9a6c8d573566052c586df83aacc5663c"},
+    {file = "cytoolz-1.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5291b117d71652a817ec164e7011f18e6a51f8a352cc9a70ed5b976c51102fda"},
+    {file = "cytoolz-1.1.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:8caef62f846a9011676c51bda9189ae394cdd6bb17f2946ecaedc23243268320"},
+    {file = "cytoolz-1.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:de425c5a8e3be7bb3a195e19191d28d9eb3c2038046064a92edc4505033ec9cb"},
+    {file = "cytoolz-1.1.0-cp312-cp312-win32.whl", hash = "sha256:296440a870e8d1f2e1d1edf98f60f1532b9d3ab8dfbd4b25ec08cd76311e79e5"},
+    {file = "cytoolz-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:07156987f224c6dac59aa18fb8bf91e1412f5463961862716a3381bf429c8699"},
+    {file = "cytoolz-1.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:23e616b38f5b3160c7bb45b0f84a8f3deb4bd26b29fb2dfc716f241c738e27b8"},
+    {file = "cytoolz-1.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:76c9b58555300be6dde87a41faf1f97966d79b9a678b7a526fcff75d28ef4945"},
+    {file = "cytoolz-1.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:d1d638b10d3144795655e9395566ce35807df09219fd7cacd9e6acbdef67946a"},
+    {file = "cytoolz-1.1.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:26801c1a165e84786a99e03c9c9973356caaca002d66727b761fb1042878ef06"},
+    {file = "cytoolz-1.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2a9a464542912d3272f6dccc5142df057c71c6a5cbd30439389a732df401afb7"},
+    {file = "cytoolz-1.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ed6104fa942aa5784bf54f339563de637557e3443b105760bc4de8f16a7fc79b"},
+    {file = "cytoolz-1.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56161f0ab60dc4159ec343509abaf809dc88e85c7e420e354442c62e3e7cbb77"},
+    {file = "cytoolz-1.1.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:832bd36cc9123535f1945acf6921f8a2a15acc19cfe4065b1c9b985a28671886"},
+    {file = "cytoolz-1.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1842636b6e034f229bf084c2bcdcfd36c8437e752eefd2c74ce9e2f10415cb6e"},
+    {file = "cytoolz-1.1.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:823df012ab90d2f2a0f92fea453528539bf71ac1879e518524cd0c86aa6df7b9"},
+    {file = "cytoolz-1.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f1fcf9e7e7b3487883ff3f815abc35b89dcc45c4cf81c72b7ee457aa72d197b"},
+    {file = "cytoolz-1.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4cdb3fa1772116827f263f25b0cdd44c663b6701346a56411960534a06c082de"},
+    {file = "cytoolz-1.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d1b5c95041741b81430454db65183e133976f45ac3c03454cfa8147952568529"},
+    {file = "cytoolz-1.1.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b2079fd9f1a65f4c61e6278c8a6d4f85edf30c606df8d5b32f1add88cbbe2286"},
+    {file = "cytoolz-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a92a320d72bef1c7e2d4c6d875125cf57fc38be45feb3fac1bfa64ea401f54a4"},
+    {file = "cytoolz-1.1.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:06d1c79aa51e6a92a90b0e456ebce2288f03dd6a76c7f582bfaa3eda7692e8a5"},
+    {file = "cytoolz-1.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e1d7be25f6971e986a52b6d3a0da28e1941850985417c35528f6823aef2cfec5"},
+    {file = "cytoolz-1.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:964b248edc31efc50a65e9eaa0c845718503823439d2fa5f8d2c7e974c2b5409"},
+    {file = "cytoolz-1.1.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c9ff2b3c57c79b65cb5be14a18c6fd4a06d5036fb3f33e973a9f70e9ac13ca28"},
+    {file = "cytoolz-1.1.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:22290b73086af600042d99f5ce52a43d4ad9872c382610413176e19fc1d4fd2d"},
+    {file = "cytoolz-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ade74fccd080ea793382968913ee38d7a35c921df435bbf0a6aeecf0d17574"},
+    {file = "cytoolz-1.1.0-cp313-cp313-win32.whl", hash = "sha256:db5dbcfda1c00e937426cbf9bdc63c24ebbc358c3263bfcbc1ab4a88dc52aa8e"},
+    {file = "cytoolz-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:9e2d3fe3b45c3eb7233746f7aca37789be3dceec3e07dcc406d3e045ea0f7bdc"},
+    {file = "cytoolz-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:32c559f95ff44a9ebcbd934acaa1e6dc8f3e6ffce4762a79a88528064873d6d5"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9e2cd93b28f667c5870a070ab2b8bb4397470a85c4b204f2454b0ad001cd1ca3"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f494124e141a9361f31d79875fe7ea459a3be2b9dadd90480427c0c52a0943d4"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:53a3262bf221f19437ed544bf8c0e1980c81ac8e2a53d87a9bc075dba943d36f"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:47663e57d3f3f124921f38055e86a1022d0844c444ede2e8f090d3bbf80deb65"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5a8755c4104ee4e3d5ba434c543b5f85fdee6a1f1df33d93f518294da793a60"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4d96ff3d381423af1b105295f97de86d1db51732c9566eb37378bab6670c5010"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0ec96b3d537cdf47d4e76ded199f7440715f4c71029b45445cff92c1248808c2"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:208e2f2ef90a32b0acbff3303d90d89b13570a228d491d2e622a7883a3c68148"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d416a81bb0bd517558668e49d30a7475b5445f9bbafaab7dcf066f1e9adba36"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f32e94c91ffe49af04835ee713ebd8e005c85ebe83e7e1fdcc00f27164c2d636"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15d0c6405efc040499c46df44056a5c382f551a7624a41cf3e4c84a96b988a15"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:bf069c5381d757debae891401b88b3a346ba3a28ca45ba9251103b282463fad8"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d5cf15892e63411ec1bd67deff0e84317d974e6ab2cdfefdd4a7cea2989df66"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:3e3872c21170f8341656f8692f8939e8800dcee6549ad2474d4c817bdefd62cd"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b9ddeff8e8fd65eb1fcefa61018100b2b627e759ea6ad275d2e2a93ffac147bf"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:02feeeda93e1fa3b33414eb57c2b0aefd1db8f558dd33fdfcce664a0f86056e4"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d08154ad45349162b6c37f12d5d1b2e6eef338e657b85e1621e4e6a4a69d64cb"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-win32.whl", hash = "sha256:10ae4718a056948d73ca3e1bb9ab1f95f897ec1e362f829b9d37cc29ab566c60"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1bb77bc6197e5cb19784b6a42bb0f8427e81737a630d9d7dda62ed31733f9e6c"},
+    {file = "cytoolz-1.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:563dda652c6ff52d215704fbe6b491879b78d7bbbb3a9524ec8e763483cb459f"},
+    {file = "cytoolz-1.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d542cee7c7882d2a914a33dec4d3600416fb336734df979473249d4c53d207a1"},
+    {file = "cytoolz-1.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31922849b701b0f24bb62e56eb2488dcd3aa6ae3057694bd6b3b7c4c2bc27c2f"},
+    {file = "cytoolz-1.1.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e68308d32afd31943314735c1335e4ab5696110e96b405f6bdb8f2a8dc771a16"},
+    {file = "cytoolz-1.1.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fc4bb48b3b866e1867f7c6411a4229e5b44be3989060663713e10efc24c9bd5f"},
+    {file = "cytoolz-1.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:456f77207d1445025d7ef262b8370a05492dcb1490cb428b0f3bf1bd744a89b0"},
+    {file = "cytoolz-1.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:174ebc71ebb20a9baeffce6ee07ee2cd913754325c93f99d767380d8317930f7"},
+    {file = "cytoolz-1.1.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8b3604fef602bcd53415055a4f68468339192fd17be39e687ae24f476d23d56e"},
+    {file = "cytoolz-1.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3604b959a01f64c366e7d10ec7634d5f5cfe10301e27a8f090f6eb3b2a628a18"},
+    {file = "cytoolz-1.1.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6db2127a3c1bc2f59f08010d2ae53a760771a9de2f67423ad8d400e9ba4276e8"},
+    {file = "cytoolz-1.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56584745ac647993a016a21bc76399113b7595e312f8d0a1b140c9fcf9b58a27"},
+    {file = "cytoolz-1.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:db2c4c3a7f7bd7e03bb1a236a125c8feb86c75802f4ecda6ecfaf946610b2930"},
+    {file = "cytoolz-1.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48cb8a692111a285d2b9acd16d185428176bfbffa8a7c274308525fccd01dd42"},
+    {file = "cytoolz-1.1.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d2f344ba5eb17dcf38ee37fdde726f69053f54927db8f8a1bed6ac61e5b1890d"},
+    {file = "cytoolz-1.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:abf76b1c1abd031f098f293b6d90ee08bdaa45f8b5678430e331d991b82684b1"},
+    {file = "cytoolz-1.1.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ddf9a38a5b686091265ff45b53d142e44a538cd6c2e70610d3bc6be094219032"},
+    {file = "cytoolz-1.1.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:946786755274f07bb2be0400f28adb31d7d85a7c7001873c0a8e24a503428fb3"},
+    {file = "cytoolz-1.1.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:d5b8f78b9fed79cf185ad4ddec099abeef45951bdcb416c5835ba05f0a1242c7"},
+    {file = "cytoolz-1.1.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fccde6efefdbc02e676ccb352a2ccc8a8e929f59a1c6d3d60bb78e923a49ca44"},
+    {file = "cytoolz-1.1.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:717b7775313da5f51b0fbf50d865aa9c39cb241bd4cb605df3cf2246d6567397"},
+    {file = "cytoolz-1.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5158744a09d0e0e4a4f82225e3a3c4ebf38f9ae74467aaa905467270e52f2794"},
+    {file = "cytoolz-1.1.0-cp314-cp314-win32.whl", hash = "sha256:1ed534bdbbf063b2bb28fca7d0f6723a3e5a72b086e7c7fe6d74ae8c3e4d00e2"},
+    {file = "cytoolz-1.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:472c1c9a085f5ad973ec0ad7f0b9ba0969faea6f96c9e397f6293d386f3a25ec"},
+    {file = "cytoolz-1.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:a7ad7ca3386fa86bd301be3fa36e7f0acb024f412f665937955acfc8eb42deff"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:64b63ed4b71b1ba813300ad0f06b8aff19a12cf51116e0e4f1ed837cea4debcf"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a60ba6f2ed9eb0003a737e1ee1e9fa2258e749da6477946008d4324efa25149f"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1aa58e2434d732241f7f051e6f17657e969a89971025e24578b5cbc6f1346485"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6965af3fc7214645970e312deb9bd35a213a1eaabcfef4f39115e60bf2f76867"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ddd2863f321d67527d3b67a93000a378ad6f967056f68c06467fe011278a6d0e"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4e6b428e9eb5126053c2ae0efa62512ff4b38ed3951f4d0888ca7005d63e56f5"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d758e5ef311d2671e0ae8c214c52e44617cf1e58bef8f022b547b9802a5a7f30"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a95416eca473e6c1179b48d86adcf528b59c63ce78f4cb9934f2e413afa9b56b"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36c8ede93525cf11e2cc787b7156e5cecd7340193ef800b816a16f1404a8dc6d"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c949755b6d8a649c5fbc888bc30915926f1b09fe42fea9f289e297c2f6ddd3"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1b6d37545816905a76d9ed59fa4e332f929e879f062a39ea0f6f620405cdc27"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:05332112d4087904842b36954cd1d3fc0e463a2f4a7ef9477bd241427c593c3b"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:31538ca2fad2d688cbd962ccc3f1da847329e2258a52940f10a2ac0719e526be"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:747562aa70abf219ea16f07d50ac0157db856d447f7f498f592e097cbc77df0b"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:3dc15c48b20c0f467e15e341e102896c8422dccf8efc6322def5c1b02f074629"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3c03137ee6103ba92d5d6ad6a510e86fded69cd67050bd8a1843f15283be17ac"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be8e298d88f88bd172b59912240558be3b7a04959375646e7fd4996401452941"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-win32.whl", hash = "sha256:3d407140f5604a89578285d4aac7b18b8eafa055cf776e781aabb89c48738fad"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:56e5afb69eb6e1b3ffc34716ee5f92ffbdb5cb003b3a5ca4d4b0fe700e217162"},
+    {file = "cytoolz-1.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:27b19b4a286b3ff52040efa42dbe403730aebe5fdfd2def704eb285e2125c63e"},
+    {file = "cytoolz-1.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:08a63935c66488511b7b29b06233be0be5f4123622fc8fd488f28dc1b7e4c164"},
+    {file = "cytoolz-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:93bd0afcc4cc05794507084afaefb161c3639f283ee629bd0e8654b5c0327ba8"},
+    {file = "cytoolz-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8f3d4da470cfd5cf44f6d682c6eb01363066e0af53ebe111225e44a618f9453d"},
+    {file = "cytoolz-1.1.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba6c12d0e6a67399f4102b4980f4f1bebdbf226ed0a68e84617709d4009b4e71"},
+    {file = "cytoolz-1.1.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b557071405b4aeeaa7cbec1a95d15d6c8f37622fe3f4b595311e0e226ce772c"},
+    {file = "cytoolz-1.1.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:cdb406001474726a47fbe903f3aba0de86f5c0b9c9861f55c09c366368225ae0"},
+    {file = "cytoolz-1.1.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b6072876ba56446d9ac29d349983677d6f44c6d1c6c1c6be44e66e377c57c767"},
+    {file = "cytoolz-1.1.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c3784c965c9a6822d315d099c3a85b0884ac648952815891c667b469116f1d0"},
+    {file = "cytoolz-1.1.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cc537ad78981df1a827773069fd3b7774f4478db43f518b1616efaf87d7d8f9"},
+    {file = "cytoolz-1.1.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:574ee9dfdc632db8bf9237f27f2a687d1a0b90d29d5e96cab2b21fd2b419c17d"},
+    {file = "cytoolz-1.1.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6594efbaea72dc58b368b53e745ad902c8d8cc41286f00b3743ceac464d5ef3f"},
+    {file = "cytoolz-1.1.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:7c849f9ddaf3c7faba938440f9c849235a2908b303063d49da3092a93acd695b"},
+    {file = "cytoolz-1.1.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1fef0296fb3577d0a08ad9b70344ee418f728f1ec21a768ffe774437d67ac859"},
+    {file = "cytoolz-1.1.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:1dce1e66fdf72cc474367bd7a7f2b90ec67bb8197dc3fe8ecd08f4ce3ab950a1"},
+    {file = "cytoolz-1.1.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:202fe9975efaec0085cab14a6a6050418bc041f5316f2cf098c0cd2aced4c50e"},
+    {file = "cytoolz-1.1.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:528349434601b9d55e65c6a495494de0001c9a06b431547fea4c60b5edc7d5b3"},
+    {file = "cytoolz-1.1.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3e248cdbf2a54bafdadf4486ddd32e8352f816d3caa2014e44de99f8c525d4a8"},
+    {file = "cytoolz-1.1.0-cp39-cp39-win32.whl", hash = "sha256:e63f2b70f4654648a5c6a176ae80897c0de6401f385540dce8e365019e800cfe"},
+    {file = "cytoolz-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:f731c53ed29959f105ae622b62e39603c207ed8e8cb2a40cd4accb63d9f92901"},
+    {file = "cytoolz-1.1.0-cp39-cp39-win_arm64.whl", hash = "sha256:5a2120bf9e6e8f25e1b32748424a5571e319ef03a995a8fde663fd2feec1a696"},
+    {file = "cytoolz-1.1.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:f32e93a55681d782fc6af939f6df36509d65122423cbc930be39b141064adff8"},
+    {file = "cytoolz-1.1.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5d9bc596751cbda8073e65be02ca11706f00029768fbbbc81e11a8c290bb41aa"},
+    {file = "cytoolz-1.1.0-pp311-pypy311_pp73-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b16660d01c3931951fab49db422c627897c38c1a1f0393a97582004019a4887"},
+    {file = "cytoolz-1.1.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b7de5718e2113d4efccea3f06055758cdbc17388ecc3341ba4d1d812837d7c1a"},
+    {file = "cytoolz-1.1.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a12a2a1a6bc44099491c05a12039efa08cc33a3d0f8c7b0566185e085e139283"},
+    {file = "cytoolz-1.1.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:047defa7f5f9a32f82373dbc3957289562e8a3fa58ae02ec8e4dca4f43a33a21"},
+    {file = "cytoolz-1.1.0.tar.gz", hash = "sha256:13a7bf254c3c0d28b12e2290b82aed0f0977a4c2a2bf84854fcdc7796a29f3b0"},
 ]
 
 [package.dependencies]
 toolz = ">=0.8.0"
 
 [package.extras]
-cython = ["cython"]
+cython = ["cython (>=0.29)"]
+test = ["pytest"]
 
 [[package]]
 name = "deepdiff"
@@ -2343,34 +2413,40 @@ nicer-shell = ["ipython"]
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.5"
+version = "0.15.16"
 description = ""
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "olas_operate_middleware-0.15.5-py3-none-any.whl", hash = "sha256:c9d8211ff63e72183279bcb6ebe06bc128f073ddfb085a4f0639c026b81557f2"},
-    {file = "olas_operate_middleware-0.15.5.tar.gz", hash = "sha256:dc59c8028159cb0589c2ca14455326b3113ba4f42dfa921e038835ce4f271b48"},
+    {file = "olas_operate_middleware-0.15.16-py3-none-any.whl", hash = "sha256:1178e6acf048a1204a3f6cf0cac227bba6c5f64ebdd079bcd80db018349cb47b"},
+    {file = "olas_operate_middleware-0.15.16.tar.gz", hash = "sha256:d3ea365df5a4771b4efbde84aaa1d51541f5c586faaf4edbea4599590cfd7484"},
 ]
 
 [package.dependencies]
+aiohttp = ">=3.10,<4.0"
 argon2-cffi = "23.1.0"
 clea = "0.1.0rc4"
 cryptography = ">=46.0.3,<47.0.0"
-cytoolz = "0.12.3"
+cytoolz = ">=1.0.0,<1.2.0"
 deepdiff = ">=8.6.1,<9.0.0"
 fastapi = "0.110.3"
+flask = ">=3.0,<4.0"
 halo = "0.0.31"
+hexbytes = ">=1.2,<2.0"
 multiaddr = "0.0.9"
 open-aea-cli-ipfs = ">=2.1.0,<3.0.0"
 open-aea-ledger-cosmos = ">=2.1.0,<3.0.0"
 open-aea-ledger-ethereum = ">=2.1.0,<3.0.0"
 open-aea-ledger-ethereum-flashbots = ">=2.1.0,<3.0.0"
-open-autonomy = ">=0.21.13,<0.22.0"
+open-autonomy = {version = ">=0.21.13,<0.22.0", extras = ["cli", "docker"]}
 psutil = ">=5.9.8,<6.0.0"
 pyinstaller = ">=6.8.0,<7.0.0"
+requests = ">=2.32,<3.0"
 requests-mock = ">=1.12.1,<2.0.0"
+typing_extensions = ">=4.12,<5.0"
 uvicorn = "0.27.0"
+werkzeug = ">=3.0,<4.0"
 
 [[package]]
 name = "open-aea"
@@ -4422,4 +4498,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "e3b459dc903957e2cd368dd6bd1b42606b86450786414c1aff7f62fc9fe94898"
+content-hash = "cfba3af7707e38ec69ed071f16e7c5de2ce5a1a6b185341ec9d8e04716dadd9a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1815,6 +1815,8 @@ files = [
 anyio = ">=3.0,<5"
 backoff = ">=1.11.1,<3.0"
 graphql-core = ">=3.2,<3.3"
+requests = {version = ">=2.26,<3", optional = true, markers = "extra == \"requests\""}
+requests-toolbelt = {version = ">=1.0.0,<2", optional = true, markers = "extra == \"requests\""}
 yarl = ">=1.6,<2.0"
 
 [package.extras]
@@ -4498,4 +4500,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "cfba3af7707e38ec69ed071f16e7c5de2ce5a1a6b185341ec9d8e04716dadd9a"
+content-hash = "a268615e53d5b588cddd8f7b43f3bb759f36b7222e44a3809af9db32ebf88ea8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4500,4 +4500,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "a268615e53d5b588cddd8f7b43f3bb759f36b7222e44a3809af9db32ebf88ea8"
+content-hash = "6e49f070a6b2ceb81b4ec9c00bc2aa04abe2ac6bd6c37446e24410f40657e7d3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2545,40 +2545,37 @@ pycryptodome = ">=3.10.1,<4.0.0"
 
 [[package]]
 name = "open-aea-ledger-ethereum"
-version = "2.2.3"
+version = "2.1.0"
 description = "Python package wrapping the public and private key cryptography and ledger api of Ethereum."
 optional = false
-python-versions = "<3.15,>=3.10"
+python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "open_aea_ledger_ethereum-2.2.3-py3-none-any.whl", hash = "sha256:1f4cbf53e4df6c447ef6104aadbc9bfe60746f9182f9267e2ca45b7a24017546"},
-    {file = "open_aea_ledger_ethereum-2.2.3.tar.gz", hash = "sha256:e69a4730a9ebeb7bb11c84766e69b05d03c0a8596a04971682721b73af61f40f"},
+    {file = "open_aea_ledger_ethereum-2.1.0-py3-none-any.whl", hash = "sha256:04670f26a86670052af9e4e2e675631d2ac8e40b5cae5143d9808ca36e96172d"},
+    {file = "open_aea_ledger_ethereum-2.1.0.tar.gz", hash = "sha256:56f6ca96036e7afa5ae69958455ad23087d712fbc04a0c05c23704e7449a4bd3"},
 ]
 
 [package.dependencies]
 eth-account = ">=0.13.0,<0.14.0"
+ipfshttpclient = "0.8.0a2"
 open-aea = ">=2.0.0,<3.0.0"
-requests = ">=2.32.5,<3"
 web3 = ">=7.0.0,<8"
-
-[package.extras]
-test-tools = ["docker (==7.1.0)", "pytest (>=7.0,<10)"]
 
 [[package]]
 name = "open-aea-ledger-ethereum-flashbots"
-version = "2.2.0"
+version = "2.1.0"
 description = "Python package extending the default open-aea ethereum ledger plugin to add support for flashbots."
 optional = false
-python-versions = "<3.15,>=3.10"
+python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_aea_ledger_ethereum_flashbots-2.2.0-py3-none-any.whl", hash = "sha256:be89c84a7fd5b44dc5992e54525a044fe09849c2084e51a9abfa6b13574df6e3"},
-    {file = "open_aea_ledger_ethereum_flashbots-2.2.0.tar.gz", hash = "sha256:427fcf2911bd3d95df3de2a76fb147a87c8f1cd8f383b0498143a11de25e2d22"},
+    {file = "open_aea_ledger_ethereum_flashbots-2.1.0-py3-none-any.whl", hash = "sha256:800acd6c5a22db7052d53576f719925de89626c147cf1a68982b643a2a11d45e"},
+    {file = "open_aea_ledger_ethereum_flashbots-2.1.0.tar.gz", hash = "sha256:20b7cce44c91636aec32fe311dc466ec79ab01644f9e4b8b4036c12300d43b69"},
 ]
 
 [package.dependencies]
-open-aea-flashbots = ">=2.0.0,<3.0.0"
-open-aea-ledger-ethereum = ">=2.2.0,<2.3.0"
+open-aea-flashbots = ">=2.1.0,<2.2.0"
+open-aea-ledger-ethereum = ">=2.1.0,<2.2.0"
 
 [[package]]
 name = "open-autonomy"
@@ -4503,4 +4500,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "ab4813e62186f003c16cceecd7e95d105a13e92ab4258f12abbdfd3de1515bc1"
+content-hash = "ce98b87f61c6fb6284303d3c115a38459ce809057a28e1b4649181646b36251b"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2545,37 +2545,40 @@ pycryptodome = ">=3.10.1,<4.0.0"
 
 [[package]]
 name = "open-aea-ledger-ethereum"
-version = "2.1.0"
+version = "2.2.3"
 description = "Python package wrapping the public and private key cryptography and ledger api of Ethereum."
 optional = false
-python-versions = "*"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_aea_ledger_ethereum-2.1.0-py3-none-any.whl", hash = "sha256:04670f26a86670052af9e4e2e675631d2ac8e40b5cae5143d9808ca36e96172d"},
-    {file = "open_aea_ledger_ethereum-2.1.0.tar.gz", hash = "sha256:56f6ca96036e7afa5ae69958455ad23087d712fbc04a0c05c23704e7449a4bd3"},
+    {file = "open_aea_ledger_ethereum-2.2.3-py3-none-any.whl", hash = "sha256:1f4cbf53e4df6c447ef6104aadbc9bfe60746f9182f9267e2ca45b7a24017546"},
+    {file = "open_aea_ledger_ethereum-2.2.3.tar.gz", hash = "sha256:e69a4730a9ebeb7bb11c84766e69b05d03c0a8596a04971682721b73af61f40f"},
 ]
 
 [package.dependencies]
 eth-account = ">=0.13.0,<0.14.0"
-ipfshttpclient = "0.8.0a2"
 open-aea = ">=2.0.0,<3.0.0"
+requests = ">=2.32.5,<3"
 web3 = ">=7.0.0,<8"
+
+[package.extras]
+test-tools = ["docker (==7.1.0)", "pytest (>=7.0,<10)"]
 
 [[package]]
 name = "open-aea-ledger-ethereum-flashbots"
-version = "2.1.0"
+version = "2.2.0"
 description = "Python package extending the default open-aea ethereum ledger plugin to add support for flashbots."
 optional = false
-python-versions = "<4.0,>=3.10"
+python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "open_aea_ledger_ethereum_flashbots-2.1.0-py3-none-any.whl", hash = "sha256:800acd6c5a22db7052d53576f719925de89626c147cf1a68982b643a2a11d45e"},
-    {file = "open_aea_ledger_ethereum_flashbots-2.1.0.tar.gz", hash = "sha256:20b7cce44c91636aec32fe311dc466ec79ab01644f9e4b8b4036c12300d43b69"},
+    {file = "open_aea_ledger_ethereum_flashbots-2.2.0-py3-none-any.whl", hash = "sha256:be89c84a7fd5b44dc5992e54525a044fe09849c2084e51a9abfa6b13574df6e3"},
+    {file = "open_aea_ledger_ethereum_flashbots-2.2.0.tar.gz", hash = "sha256:427fcf2911bd3d95df3de2a76fb147a87c8f1cd8f383b0498143a11de25e2d22"},
 ]
 
 [package.dependencies]
-open-aea-flashbots = ">=2.1.0,<2.2.0"
-open-aea-ledger-ethereum = ">=2.1.0,<2.2.0"
+open-aea-flashbots = ">=2.0.0,<3.0.0"
+open-aea-ledger-ethereum = ">=2.2.0,<2.3.0"
 
 [[package]]
 name = "open-autonomy"
@@ -4500,4 +4503,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "6e49f070a6b2ceb81b4ec9c00bc2aa04abe2ac6bd6c37446e24410f40657e7d3"
+content-hash = "ab4813e62186f003c16cceecd7e95d105a13e92ab4258f12abbdfd3de1515bc1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = []
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-olas-operate-middleware = "0.15.5"
+olas-operate-middleware = "0.15.16"
 tqdm = "^4.67.1"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,14 @@ include = []
 python = ">=3.10,<3.15"
 olas-operate-middleware = "0.15.16"
 tqdm = "^4.67.1"
+python-dotenv = "^0.21.1"
+gql = {version = "^3.5.0", extras = ["requests"]}
+halo = "^0.0.31"
+web3 = "^7.14.1"
+docker = "^7.1.0"
+psutil = "^5.9.8"
+open-aea-ledger-ethereum = "^2.1.0"
+open-autonomy = "^0.21.13"
 
 [tool.poetry.group.dev.dependencies]
 pexpect = "^4.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ web3 = "^7.14.1"
 docker = "^7.1.0"
 psutil = "^5.9.8"
 open-aea-ledger-ethereum = "^2.1.0"
-open-autonomy = "^0.21.13"
+open-autonomy = "0.21.13"
 
 [tool.poetry.group.dev.dependencies]
 pexpect = "^4.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,22 +11,19 @@ include = []
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
 olas-operate-middleware = "0.15.16"
-tqdm = "^4.67.1"
-python-dotenv = "^0.21.1"
-gql = {version = "^3.5.0", extras = ["requests"]}
-halo = "^0.0.31"
-web3 = "^7.14.1"
-docker = "^7.1.0"
-psutil = "^5.9.8"
-# Pinned to 2.2.3 — 2.2.4 returns plain dict tx receipts where 2.2.3
-# returned AttrDicts, breaking `autonomy/chain/tx.py:258 settle()`'s
-# `.blockNumber` access. Drop the pin once open-aea / open-autonomy ship
-# a fix that handles dict-shaped receipts.
-open-aea-ledger-ethereum = "2.2.3"
+tqdm = "4.67.3"
+python-dotenv = "0.21.1"
+gql = {version = "3.5.0", extras = ["requests"]}
+halo = "0.0.31"
+web3 = "7.14.1"
+docker = "7.1.0"
+psutil = "5.9.8"
+open-aea = "2.1.0"
+open-aea-ledger-ethereum = "2.1.0"
 open-autonomy = "0.21.13"
 
 [tool.poetry.group.dev.dependencies]
-pexpect = "^4.9.0"
+pexpect = "4.9.0"
 
 [tool.pytest.ini_options]
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,11 @@ halo = "^0.0.31"
 web3 = "^7.14.1"
 docker = "^7.1.0"
 psutil = "^5.9.8"
-open-aea-ledger-ethereum = "^2.1.0"
+# Pinned to 2.2.3 — 2.2.4 returns plain dict tx receipts where 2.2.3
+# returned AttrDicts, breaking `autonomy/chain/tx.py:258 settle()`'s
+# `.blockNumber` access. Drop the pin once open-aea / open-autonomy ship
+# a fix that handles dict-shaped receipts.
+open-aea-ledger-ethereum = "2.2.3"
 open-autonomy = "0.21.13"
 
 [tool.poetry.group.dev.dependencies]

--- a/run_service.sh
+++ b/run_service.sh
@@ -62,10 +62,24 @@ command -v docker >/dev/null 2>&1 ||
   exit 1
 }
 
-docker rm -f abci0 node0 trader_abci_0 trader_tm_0 &> /dev/null ||
+# Verify docker daemon is up (independently of whether any containers exist
+# to clean up — the prior `docker rm -f <names>` form would exit "Docker is
+# not running" whenever the named containers happened to be absent).
+docker info &> /dev/null ||
 { echo >&2 "Docker is not running!";
   exit 1
 }
+
+# Remove any leftover quickstart-managed containers. Fragments mirror
+# scripts/pearl_migration/status.py:QUICKSTART_CONTAINER_FRAGMENTS so both
+# entrypoints converge on the same notion of "what's a quickstart container".
+# `_abci_0` / `_tm_0` catch the per-service variants the middleware emits
+# (`trader_abci_0`, `meme_factory_tm_0`, ...); `abci0` / `node0` catch the
+# pre-`<service>_` legacy names.
+qs_containers=$(docker ps -a --format '{{.Names}}' | grep -E 'abci0|node0|_abci_0|_tm_0' || true)
+if [ -n "$qs_containers" ]; then
+    docker rm -f $qs_containers &> /dev/null
+fi
 
 # own the data directory (if required)
 # this is for migrating from an old version of the agents (using open-autonomy <0.19.9), which used to save these files as root

--- a/scripts/pearl_migration/README.md
+++ b/scripts/pearl_migration/README.md
@@ -1,0 +1,12 @@
+# Quickstart → Pearl migration
+
+Helpers used by `migrate_to_pearl.py` at the repo root. See that script for usage.
+
+Modules:
+
+- `detect.py` — locate `.operate` stores, classify Mode A (fresh copy) vs Mode B (merge).
+- `status.py` — read-only source-of-truth queries: docker container presence, port probes, on-chain `ServiceRegistry.ownerOf`, Safe owners + threshold, and filesystem-ownership probes (`is_root_owned`, `any_root_owned_under`).
+- `stop.py` — wrap middleware service stop and double-check known docker containers.
+- `transfer.py` — the only `MUST_BUILD` on-chain piece: transfer the ServiceRegistry NFT from the quickstart master Safe to the Pearl master Safe. Service-Safe owner swap reuses `gnosis.swap_owner` directly.
+- `filesystem.py` — copy `services/sc-{uuid}/` and the referenced `keys/0x{addr}` files. No path rewriting (computed env vars are re-resolved at deploy time — grep for `STORE_PATH` in `olas-operate-middleware/operate/services/service.py`).
+- `prompts.py` — interactive helpers for collisions and yes/no questions.

--- a/scripts/pearl_migration/__init__.py
+++ b/scripts/pearl_migration/__init__.py
@@ -1,0 +1,1 @@
+"""Quickstart -> Pearl migration utilities."""

--- a/scripts/pearl_migration/detect.py
+++ b/scripts/pearl_migration/detect.py
@@ -1,0 +1,222 @@
+"""Locate quickstart and Pearl `.operate` stores and classify migration mode.
+
+Reuses the middleware's official primitives where possible:
+
+- `operate.services.service.Service` — service config dataclass + loader.
+- `operate.wallet.master.MasterWalletManager` — wallet existence check.
+- `operate.constants.{OPERATE, SERVICES_DIR, KEYS_DIR, WALLETS_DIR}`.
+- `operate.services.service.SERVICE_CONFIG_PREFIX`.
+
+`OperateApp` is built lazily via `OperateStore.operate_app(password=...)` so
+read-only paths (preflight, dry-run, mode classification) don't trigger
+middleware migrations or version-bump backups.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+
+from operate.constants import KEYS_DIR, SERVICES_DIR, WALLETS_DIR
+from operate.operate_types import LedgerType
+from operate.services.service import SERVICE_CONFIG_PREFIX, Service
+from operate.wallet.master import MasterWalletManager
+
+if TYPE_CHECKING:
+    from operate.cli import OperateApp
+
+
+class Mode(Enum):
+    """Migration mode."""
+
+    FRESH_COPY = "fresh_copy"  # Pearl `.operate` does not exist (or has no wallet)
+    MERGE = "merge"            # Pearl has its own master wallet; we must merge
+    NOOP = "noop"              # Quickstart `.operate` already is `~/.operate`
+
+
+@dataclass(frozen=True)
+class OperateStore:
+    """One on-disk `.operate` directory.
+
+    Thin facade — listing services and checking wallet existence delegate to
+    the middleware. Creating a real `OperateApp` is deferred until the caller
+    actually needs to run migrations / sign on-chain (see `operate_app`).
+
+    `frozen=True`: prevents accidental mutation of `root` (which would
+    invalidate the cached `OperateApp`). The lazy app is held in a
+    private dict to satisfy the immutability constraint while still
+    allowing memoization.
+    """
+
+    root: Path                                  # absolute, resolved
+    _state: Dict[str, "OperateApp"] = field(
+        default_factory=dict, repr=False, compare=False, hash=False,
+    )
+
+    def __post_init__(self) -> None:
+        # Enforce the "absolute + resolved" invariant the docstring promises.
+        # Always resolve so absolute paths with `..` segments / symlinks
+        # also normalize. Use object.__setattr__ because `frozen=True`
+        # blocks plain assignment. Wrap in try/except so a permissions error
+        # on Path.resolve() doesn't surface as a raw OSError out of a
+        # dataclass constructor.
+        try:
+            resolved = self.root.resolve()
+        except OSError as exc:
+            raise ValueError(
+                f"Cannot resolve store root '{self.root}': {exc}. "
+                "Pass an accessible absolute path."
+            ) from exc
+        if resolved != self.root:
+            # Tell the user when resolution changed the path — otherwise
+            # subsequent log lines, error messages and the rename-source
+            # step refer to a path they may not recognise (e.g. a symlink
+            # target). Lazy import: prompts.py depends on operate.* which
+            # we want kept off the detect.py import path.
+            from .prompts import info as _info
+            _info(f"Resolved store root: {self.root} -> {resolved}")
+            object.__setattr__(self, "root", resolved)
+
+    @property
+    def wallets_dir(self) -> Path:
+        return self.root / WALLETS_DIR
+
+    @property
+    def keys_dir(self) -> Path:
+        return self.root / KEYS_DIR
+
+    @property
+    def services_dir(self) -> Path:
+        return self.root / SERVICES_DIR
+
+    def has_master_wallet(self) -> bool:
+        """True iff the Ethereum master wallet keystore is present.
+
+        Uses the middleware's `MasterWalletManager.exists` so we share the
+        same "what counts as a wallet" definition the daemon uses.
+        """
+        if not self.wallets_dir.exists():
+            return False
+        return MasterWalletManager(path=self.wallets_dir).exists(LedgerType.ETHEREUM)
+
+    def services(self) -> List[Service]:
+        """Return all `sc-*` services as middleware `Service` objects.
+
+        Side-effect-free: uses `Service.load(path)` directly rather than
+        spinning up an `OperateApp` (which would run migrations). Services
+        whose `config.json` won't load are skipped with a `warn(...)` —
+        they get reported via `failed_services()` so callers can refuse
+        to drain master wallets when any service was orphaned.
+        """
+        loaded, _ = self._enumerate()
+        return loaded
+
+    def failed_services(self) -> List[Tuple[Path, BaseException]]:
+        """Return `(path, exception)` for any `sc-*` dir that couldn't load.
+
+        Companion to `services()` — exposes the dropped entries so callers
+        can refuse destructive follow-ups (drains, source rename) when the
+        migration plan is incomplete.
+        """
+        _, failed = self._enumerate()
+        return failed
+
+    def _enumerate(
+        self,
+    ) -> Tuple[List[Service], List[Tuple[Path, BaseException]]]:
+        # Local import to avoid a circular dependency at module load.
+        from .prompts import warn
+
+        loaded: List[Service] = []
+        failed: List[Tuple[Path, BaseException]] = []
+        if not self.services_dir.exists():
+            return loaded, failed
+        for child in sorted(self.services_dir.iterdir()):
+            if not child.is_dir() or not child.name.startswith(SERVICE_CONFIG_PREFIX):
+                continue
+            if not (child / "config.json").exists():
+                continue
+            try:
+                loaded.append(Service.load(path=child))
+            except Exception as exc:  # pylint: disable=broad-except
+                # Bad config / version mismatch / etc. Surface so the caller
+                # can refuse to drain master if any service was orphaned.
+                warn(f"Skipping {child.name}: cannot load config ({exc!r}).")
+                failed.append((child, exc))
+        return loaded, failed
+
+    def operate_app(self, password: Optional[str] = None) -> "OperateApp":
+        """Lazily build (and cache) an `OperateApp` for this `.operate` root.
+
+        Heavy: instantiation runs the middleware's migration suite and may
+        backup the dir on a version bump. Only call this once you're
+        committed to actually mutating / signing against the store. Pass
+        `password` when known so `app.password = ...` is set right away.
+        """
+        cached = self._state.get("app")
+        if cached is None:
+            from operate.cli import OperateApp  # local import: heavy module
+
+            cached = OperateApp(home=self.root)
+            self._state["app"] = cached
+        if password is not None:
+            cached.password = password
+        return cached
+
+
+@dataclass(frozen=True)
+class Discovery:
+    """Result of discovery.
+
+    Carries its own invariant: `mode == NOOP` iff the two stores point at
+    the same root. The factory `discover()` upholds this; `__post_init__`
+    re-checks so direct construction (in tests, etc.) can't lie.
+    """
+
+    quickstart: OperateStore
+    pearl: OperateStore
+    mode: Mode
+
+    def __post_init__(self) -> None:
+        same_root = self.quickstart.root == self.pearl.root
+        if same_root and self.mode != Mode.NOOP:
+            raise ValueError(
+                f"Discovery: stores share root {self.quickstart.root} but "
+                f"mode is {self.mode}; expected Mode.NOOP."
+            )
+        if not same_root and self.mode == Mode.NOOP:
+            raise ValueError(
+                f"Discovery: mode is NOOP but stores have different roots "
+                f"({self.quickstart.root} vs {self.pearl.root})."
+            )
+
+    @property
+    def is_noop(self) -> bool:
+        return self.mode == Mode.NOOP
+
+
+def discover(
+    quickstart_root: Optional[Path] = None,
+    pearl_root: Optional[Path] = None,
+) -> Discovery:
+    """Discover the two stores and classify the migration mode.
+
+    `quickstart_root` defaults to `<cwd>/.operate`. `pearl_root` defaults to
+    `~/.operate`. Both are resolved (symlinks followed) before comparison so
+    the no-op detection is reliable.
+    """
+    qs_root = (quickstart_root or Path.cwd() / ".operate").resolve()
+    pl_root = (pearl_root or Path.home() / ".operate").resolve()
+
+    qs = OperateStore(root=qs_root)
+    pl = OperateStore(root=pl_root)
+
+    if qs_root == pl_root:
+        return Discovery(quickstart=qs, pearl=pl, mode=Mode.NOOP)
+
+    if not pl_root.exists() or not pl.has_master_wallet():
+        return Discovery(quickstart=qs, pearl=pl, mode=Mode.FRESH_COPY)
+
+    return Discovery(quickstart=qs, pearl=pl, mode=Mode.MERGE)

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -74,6 +74,15 @@ def fix_root_ownership(store: OperateStore) -> None:
     gid = os.getgid()
     successful: List[Path] = []
     for service_dir in store.services_dir.iterdir():
+        # Skip anything that isn't a real service directory. The
+        # middleware names service dirs `sc-{uuid}`; everything else
+        # (macOS `.DS_Store`, stray dotfiles, leftover backups from a
+        # previous abort) is not part of the service tree and must not
+        # be chowned — `.DS_Store` in particular is owned by root on
+        # some macOS setups, which would otherwise force a sudo prompt
+        # for a file the migration doesn't even copy.
+        if not service_dir.is_dir() or not service_dir.name.startswith("sc-"):
+            continue
         # Defence in depth: --quickstart-home with a symlink/typo could
         # point us outside the actual store. Validate the resolution to
         # avoid `chown -R`-ing whatever a stray symlink points at.

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -86,7 +86,7 @@ def fix_root_ownership(store: OperateStore) -> None:
         # discovering the gap mid-copy.
         needs_chown.append(service_dir)
     if not needs_chown:
-        return
+        return  # services_dir exists but is empty; nothing to chown
 
     uid = os.getuid()
     gid = os.getgid()

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -1,0 +1,204 @@
+"""File-level migration: copy `services/sc-{uuid}/` and the agent keys it references.
+
+No path rewriting: the middleware re-resolves `provision_type=computed`
+env vars (including `STORE_PATH`) at every deployment. The override lives
+inside `Service.deploy(...)` in the middleware — grep for `"STORE_PATH": "/data"`
+in `olas-operate-middleware/operate/services/service.py` if you need to
+verify. Either way, a plain `cp -r` is sufficient once collisions are handled.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from operate.services.service import Service
+
+from .detect import OperateStore
+from .prompts import CollisionChoice, backup_suffix, collision, info, warn
+from .status import any_root_owned_under
+
+
+class MissingAgentKey(OSError):
+    """Raised by `merge_service` when an agent key referenced by the
+    service config is not present at the source `keys/` dir.
+
+    Subclasses `OSError` so the existing `(OSError, shutil.Error)` catch
+    in `_run_mode_b` aggregates it into `MigrationOutcome.unmigratable`
+    with the standard "on-chain committed but filesystem copy failed"
+    message — the user is then told exactly which key is missing and
+    that the on-chain side is already done.
+
+    Previously this case was a `warn(...)` + skip, which left the user
+    with an unstartable service (Pearl can't sign for the missing
+    agent) and no entry in `MigrationOutcome` to surface the problem.
+    """
+
+
+@dataclass
+class CopyOutcome:
+    service_id: str
+    service_copied: bool
+    service_skipped: bool
+    keys_copied: List[str]
+    keys_skipped: List[str]
+    backups_made: List[Path]
+
+
+def fix_root_ownership(store: OperateStore) -> None:
+    """chown -R the user if any persistent_data is root-owned.
+
+    Mirrors the cleanup block at the top of `run_service.sh` (look for the
+    `.operate/services/sc-*` chown loop). Raises on any failure: the
+    callers (`_run_mode_a` / `_run_mode_b`) immediately follow with
+    `shutil.copytree` / `merge_service` over the same tree, so silently
+    leaving root-owned files would corrupt the destination mid-copy.
+    """
+    if not store.services_dir.exists():
+        return
+    store_root = store.root.resolve()
+    needs_chown = []
+    for service_dir in store.services_dir.iterdir():
+        # Defence in depth: --quickstart-home with a symlink/typo could
+        # point us outside the actual store. Validate BOTH the service
+        # dir AND the persistent_data resolution; either could escape via
+        # symlinks (`services/sc-foo -> ../somewhere`) and we'd otherwise
+        # `chown -R` whatever they pointed at.
+        for candidate in (service_dir, service_dir / "persistent_data"):
+            try:
+                resolved = candidate.resolve()
+                resolved.relative_to(store_root)
+            except (OSError, ValueError) as exc:
+                raise RuntimeError(
+                    f"refusing to chown {candidate}: not inside store root "
+                    f"{store_root} ({exc})"
+                )
+        pdata = service_dir / "persistent_data"
+        if any_root_owned_under(pdata):
+            needs_chown.append(pdata)
+    if not needs_chown:
+        return
+
+    uid = os.getuid()
+    gid = os.getgid()
+    for pdata in needs_chown:
+        warn(f"Root-owned files found under {pdata}; running 'sudo chown -R {uid}:{gid}'.")
+        try:
+            subprocess.run(
+                ["sudo", "chown", "-R", f"{uid}:{gid}", str(pdata)],
+                check=True,
+                timeout=120,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            # Don't continue: the next step copies this tree as the current
+            # user, which will error out partway and leave a half-populated
+            # destination. Better to abort cleanly here.
+            raise RuntimeError(
+                f"could not chown {pdata}: {exc}. Run 'sudo chown -R {uid}:{gid} "
+                f"{pdata}' manually and re-run the migration."
+            )
+
+
+def fresh_copy_store(src: OperateStore, dest_root: Path) -> None:
+    """Mode A: copy the whole `.operate` to `dest_root`.
+
+    Refuses if `dest_root` already exists (the orchestrator handles the
+    "exists but empty Pearl init" case explicitly before calling here).
+    """
+    if dest_root.exists():
+        raise FileExistsError(
+            f"Destination already exists: {dest_root} — refuse to overwrite."
+        )
+    dest_root.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src.root, dest_root, symlinks=True)
+    info(f"Copied {src.root} -> {dest_root}")
+
+
+def _backup_then_remove(target: Path) -> Path:
+    """Rename `target` to `target.bak.<ts>` and return the new path."""
+    bak = target.with_name(f"{target.name}.{backup_suffix()}")
+    target.rename(bak)
+    return bak
+
+
+def merge_service(
+    service: Service,
+    src: OperateStore,
+    dest: OperateStore,
+) -> CopyOutcome:
+    """Copy one service directory + its referenced keys into `dest`.
+
+    On collision the user is prompted (skip vs overwrite-with-backup). Backups
+    are timestamped siblings — never deleted by this script.
+    """
+    backups: List[Path] = []
+    sid = service.service_config_id
+
+    # ---- service directory --------------------------------------------------
+    dest.services_dir.mkdir(parents=True, exist_ok=True)
+    dest_service_dir = dest.services_dir / sid
+
+    service_copied = False
+    service_skipped = False
+    if dest_service_dir.exists():
+        choice = collision(dest_service_dir, kind="service")
+        if choice == CollisionChoice.SKIP:
+            service_skipped = True
+        else:
+            backups.append(_backup_then_remove(dest_service_dir))
+            shutil.copytree(service.path, dest_service_dir, symlinks=True)
+            service_copied = True
+    else:
+        shutil.copytree(service.path, dest_service_dir, symlinks=True)
+        service_copied = True
+
+    # ---- agent keys ---------------------------------------------------------
+    dest.keys_dir.mkdir(parents=True, exist_ok=True)
+    keys_copied: List[str] = []
+    keys_skipped: List[str] = []
+    for addr in service.agent_addresses:
+        src_key = src.keys_dir / addr
+        if not src_key.exists():
+            # Pearl cannot sign for an agent whose key is absent; a
+            # "skip + warn" here would leave the user with an unstartable
+            # service and no entry in the migration summary. Raise so the
+            # caller aggregates it into `unmigratable` with the
+            # on-chain-already-committed remediation message.
+            raise MissingAgentKey(
+                f"agent key {addr} referenced by {sid} not found at "
+                f"{src_key} — without it Pearl cannot sign for this "
+                "agent and the service will not start."
+            )
+        dest_key = dest.keys_dir / addr
+        if dest_key.exists():
+            choice = collision(dest_key, kind="key")
+            if choice == CollisionChoice.SKIP:
+                keys_skipped.append(addr)
+                continue
+            backups.append(_backup_then_remove(dest_key))
+        shutil.copy2(src_key, dest_key)
+        keys_copied.append(addr)
+
+    return CopyOutcome(
+        service_id=sid,
+        service_copied=service_copied,
+        service_skipped=service_skipped,
+        keys_copied=keys_copied,
+        keys_skipped=keys_skipped,
+        backups_made=backups,
+    )
+
+
+def rename_source_for_rollback(src: OperateStore) -> Path:
+    """Rename the source `.operate` so a re-run won't pick it up.
+
+    Returns the new path. Never deletes.
+    """
+    new_path = src.root.with_name(f"{src.root.name}.migrated.{backup_suffix()}")
+    src.root.rename(new_path)
+    info(f"Renamed source -> {new_path}")
+    return new_path

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -50,13 +50,17 @@ class CopyOutcome:
 
 
 def fix_root_ownership(store: OperateStore) -> None:
-    """chown -R the user if any persistent_data is root-owned.
+    """chown -R the user if any service tree contains root-owned files.
 
-    Mirrors the cleanup block at the top of `run_service.sh` (look for the
-    `.operate/services/sc-*` chown loop). Raises on any failure: the
-    callers (`_run_mode_a` / `_run_mode_b`) immediately follow with
-    `shutil.copytree` / `merge_service` over the same tree, so silently
-    leaving root-owned files would corrupt the destination mid-copy.
+    Docker leaves root-owned files in `persistent_data/` AND under
+    `deployment/nodes/node0/{config,data}/` (tendermint validator keys
+    and state). The original `run_service.sh` cleanup block only chowns
+    `persistent_data` because it then deletes and recreates `deployment`,
+    but migration copies the whole service tree — so any root-owned file
+    anywhere under it will fail the subsequent `shutil.copytree`. Raises
+    on any failure: callers (`_run_mode_a` / `_run_mode_b`) immediately
+    follow with the copy and silent skip would corrupt the destination
+    mid-copy.
     """
     if not store.services_dir.exists():
         return
@@ -64,32 +68,28 @@ def fix_root_ownership(store: OperateStore) -> None:
     needs_chown = []
     for service_dir in store.services_dir.iterdir():
         # Defence in depth: --quickstart-home with a symlink/typo could
-        # point us outside the actual store. Validate BOTH the service
-        # dir AND the persistent_data resolution; either could escape via
-        # symlinks (`services/sc-foo -> ../somewhere`) and we'd otherwise
-        # `chown -R` whatever they pointed at.
-        for candidate in (service_dir, service_dir / "persistent_data"):
-            try:
-                resolved = candidate.resolve()
-                resolved.relative_to(store_root)
-            except (OSError, ValueError) as exc:
-                raise RuntimeError(
-                    f"refusing to chown {candidate}: not inside store root "
-                    f"{store_root} ({exc})"
-                )
-        pdata = service_dir / "persistent_data"
-        if any_root_owned_under(pdata):
-            needs_chown.append(pdata)
+        # point us outside the actual store. Validate the resolution to
+        # avoid `chown -R` ing whatever a stray symlink points at.
+        try:
+            resolved = service_dir.resolve()
+            resolved.relative_to(store_root)
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(
+                f"refusing to chown {service_dir}: not inside store root "
+                f"{store_root} ({exc})"
+            )
+        if any_root_owned_under(service_dir):
+            needs_chown.append(service_dir)
     if not needs_chown:
         return
 
     uid = os.getuid()
     gid = os.getgid()
-    for pdata in needs_chown:
-        warn(f"Root-owned files found under {pdata}; running 'sudo chown -R {uid}:{gid}'.")
+    for target in needs_chown:
+        warn(f"Root-owned files found under {target}; running 'sudo chown -R {uid}:{gid}'.")
         try:
             subprocess.run(
-                ["sudo", "chown", "-R", f"{uid}:{gid}", str(pdata)],
+                ["sudo", "chown", "-R", f"{uid}:{gid}", str(target)],
                 check=True,
                 timeout=120,
             )
@@ -98,8 +98,8 @@ def fix_root_ownership(store: OperateStore) -> None:
             # user, which will error out partway and leave a half-populated
             # destination. Better to abort cleanly here.
             raise RuntimeError(
-                f"could not chown {pdata}: {exc}. Run 'sudo chown -R {uid}:{gid} "
-                f"{pdata}' manually and re-run the migration."
+                f"could not chown {target}: {exc}. Run 'sudo chown -R {uid}:{gid} "
+                f"{target}' manually and re-run the migration."
             )
 
 

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -20,7 +20,6 @@ from operate.services.service import Service
 
 from .detect import OperateStore
 from .prompts import CollisionChoice, backup_suffix, collision, info, warn
-from .status import any_root_owned_under
 
 
 class MissingAgentKey(OSError):
@@ -78,8 +77,14 @@ def fix_root_ownership(store: OperateStore) -> None:
                 f"refusing to chown {service_dir}: not inside store root "
                 f"{store_root} ({exc})"
             )
-        if any_root_owned_under(service_dir):
-            needs_chown.append(service_dir)
+        # Always chown unconditionally. Detection via Path.rglob + stat is
+        # unreliable on Python 3.14 against trees containing dirs the
+        # current user can't traverse (rglob silently skips, leaving
+        # root-owned files inside undetected). chown -R to the current
+        # uid:gid is idempotent — a no-op if everything is already
+        # user-owned — so paying the sudo invocation is cheaper than
+        # discovering the gap mid-copy.
+        needs_chown.append(service_dir)
     if not needs_chown:
         return
 

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -94,22 +94,27 @@ def fix_root_ownership(store: OperateStore) -> None:
                 f"refusing to chown {service_dir}: not inside store root "
                 f"{store_root} ({exc})"
             )
-        warn(f"Root-owned files found under {service_dir}; running 'sudo -n chown -RP {uid}:{gid}'.")
+        warn(
+            f"Root-owned files found under {service_dir}; running "
+            f"'sudo chown -RP {uid}:{gid}'. You may be prompted for your sudo password."
+        )
         try:
             subprocess.run(
-                # `-n` (sudo): non-interactive — fail fast on machines that
-                # require a sudo password instead of hanging for 120s on a
-                # blocked tty prompt.
+                # Plain interactive `sudo` (no `-n`): legacy
+                # `run_service.sh` does the same and prints the same
+                # "Please enter sudo password" notice. Using `-n` here
+                # would fail immediately on machines without passwordless
+                # sudo without ever giving the user a chance to type the
+                # password, which is exactly the QA failure this replaces.
                 # `-RP` (chown): recursive but DO NOT traverse symbolic links
                 # — a stray symlink under `persistent_data/` (e.g. pointing
                 # at `/etc`) would otherwise have its target chowned to the
                 # current user.
-                ["sudo", "-n", "chown", "-RP", f"{uid}:{gid}", str(service_dir)],
+                ["sudo", "chown", "-RP", f"{uid}:{gid}", str(service_dir)],
                 check=True,
-                timeout=120,
             )
             successful.append(service_dir)
-        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
             # Don't continue: the next step copies this tree as the current
             # user, which will error out partway and leave a half-populated
             # destination. Better to abort cleanly here. Include the list
@@ -122,7 +127,7 @@ def fix_root_ownership(store: OperateStore) -> None:
                 f"Currently in indeterminate state (chown may have walked "
                 f"partway before failing): {service_dir}. "
                 f"Run 'sudo chown -RP {uid}:{gid} {service_dir}' manually "
-                "(plus enable passwordless sudo if required) and re-run."
+                "and re-run."
             )
 
 

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -49,26 +49,34 @@ class CopyOutcome:
 
 
 def fix_root_ownership(store: OperateStore) -> None:
-    """chown -R the user if any service tree contains root-owned files.
+    """`sudo chown -RP` every service directory whose resolved path stays inside the store root, to the current uid:gid.
 
     Docker leaves root-owned files in `persistent_data/` AND under
     `deployment/nodes/node0/{config,data}/` (tendermint validator keys
     and state). The original `run_service.sh` cleanup block only chowns
     `persistent_data` because it then deletes and recreates `deployment`,
     but migration copies the whole service tree — so any root-owned file
-    anywhere under it will fail the subsequent `shutil.copytree`. Raises
-    on any failure: callers (`_run_mode_a` / `_run_mode_b`) immediately
-    follow with the copy and silent skip would corrupt the destination
-    mid-copy.
+    anywhere under it will fail the subsequent `shutil.copytree`.
+
+    Detection-via-`Path.rglob`+`stat` was tried first but is unreliable
+    on Python 3.14 against trees containing dirs the current user can't
+    traverse (rglob silently skips, leaving root-owned files inside
+    undetected). `chown` with current uid:gid is idempotent — a no-op
+    when nothing's actually root-owned — so paying the sudo invocation
+    is cheaper than discovering the gap mid-copy. Raises on any failure:
+    callers (`_run_mode_a` / `_run_mode_b`) immediately follow with the
+    copy, and silent skip would corrupt the destination mid-copy.
     """
     if not store.services_dir.exists():
         return
     store_root = store.root.resolve()
-    needs_chown = []
+    uid = os.getuid()
+    gid = os.getgid()
+    successful: List[Path] = []
     for service_dir in store.services_dir.iterdir():
         # Defence in depth: --quickstart-home with a symlink/typo could
         # point us outside the actual store. Validate the resolution to
-        # avoid `chown -R` ing whatever a stray symlink points at.
+        # avoid `chown -R`-ing whatever a stray symlink points at.
         try:
             resolved = service_dir.resolve()
             resolved.relative_to(store_root)
@@ -77,34 +85,35 @@ def fix_root_ownership(store: OperateStore) -> None:
                 f"refusing to chown {service_dir}: not inside store root "
                 f"{store_root} ({exc})"
             )
-        # Always chown unconditionally. Detection via Path.rglob + stat is
-        # unreliable on Python 3.14 against trees containing dirs the
-        # current user can't traverse (rglob silently skips, leaving
-        # root-owned files inside undetected). chown -R to the current
-        # uid:gid is idempotent — a no-op if everything is already
-        # user-owned — so paying the sudo invocation is cheaper than
-        # discovering the gap mid-copy.
-        needs_chown.append(service_dir)
-    if not needs_chown:
-        return  # services_dir exists but is empty; nothing to chown
-
-    uid = os.getuid()
-    gid = os.getgid()
-    for target in needs_chown:
-        warn(f"Root-owned files found under {target}; running 'sudo chown -R {uid}:{gid}'.")
+        warn(f"Root-owned files found under {service_dir}; running 'sudo -n chown -RP {uid}:{gid}'.")
         try:
             subprocess.run(
-                ["sudo", "chown", "-R", f"{uid}:{gid}", str(target)],
+                # `-n` (sudo): non-interactive — fail fast on machines that
+                # require a sudo password instead of hanging for 120s on a
+                # blocked tty prompt.
+                # `-RP` (chown): recursive but DO NOT traverse symbolic links
+                # — a stray symlink under `persistent_data/` (e.g. pointing
+                # at `/etc`) would otherwise have its target chowned to the
+                # current user.
+                ["sudo", "-n", "chown", "-RP", f"{uid}:{gid}", str(service_dir)],
                 check=True,
                 timeout=120,
             )
+            successful.append(service_dir)
         except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
             # Don't continue: the next step copies this tree as the current
             # user, which will error out partway and leave a half-populated
-            # destination. Better to abort cleanly here.
+            # destination. Better to abort cleanly here. Include the list
+            # of dirs already mutated so the user has an audit trail —
+            # `chown -R` to the current uid is irreversible without backups.
+            already = ", ".join(str(t) for t in successful) or "(none)"
             raise RuntimeError(
-                f"could not chown {target}: {exc}. Run 'sudo chown -R {uid}:{gid} "
-                f"{target}' manually and re-run the migration."
+                f"could not chown {service_dir}: {exc}. "
+                f"Already mutated: {already}. "
+                f"Currently in indeterminate state (chown may have walked "
+                f"partway before failing): {service_dir}. "
+                f"Run 'sudo chown -RP {uid}:{gid} {service_dir}' manually "
+                "(plus enable passwordless sudo if required) and re-run."
             )
 
 

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -139,6 +139,11 @@ def merge_service(
 
     On collision the user is prompted (skip vs overwrite-with-backup). Backups
     are timestamped siblings — never deleted by this script.
+
+    Assumes both stores share the same master password — the caller must
+    have already aligned them via `align_quickstart_password` so the
+    agent keys can be copied verbatim and decrypt under the destination
+    password at deploy time.
     """
     backups: List[Path] = []
     sid = service.service_config_id

--- a/scripts/pearl_migration/filesystem.py
+++ b/scripts/pearl_migration/filesystem.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import List
 
+from operate.constants import NO_STAKING_PROGRAM_ID
 from operate.services.service import Service
 
 from .detect import OperateStore
@@ -224,6 +225,37 @@ def merge_service(
         keys_skipped=keys_skipped,
         backups_made=backups,
     )
+
+
+def reset_services_staking_to_no_staking(store: OperateStore) -> List[str]:
+    """Pin every service's `staking_program_id` to `no_staking` and persist.
+
+    Uses `OperateStore.services()` (which returns middleware `Service`
+    instances via `Service.load(path)`) and the inherited
+    `LocalResource.store()` — the same mechanism Mode B uses inline in
+    `_migrate_one_service`. Mode A calls this on the destination AFTER
+    `fresh_copy_store` so the source `.operate/` we're about to rename
+    stays an untouched rollback.
+
+    Returns the list of `service_config_id`s that were rewritten.
+    Already-`no_staking` services don't trigger a `store()` so a re-run
+    is a no-op (no spurious mtime bump). Services that fail to load are
+    surfaced via `OperateStore.failed_services()` per existing convention
+    and silently skipped here — re-checking via `services()` would warn
+    about them twice.
+    """
+    updated: List[str] = []
+    for svc in store.services():
+        changed = False
+        for chain_config in svc.chain_configs.values():
+            user_params = chain_config.chain_data.user_params
+            if user_params.staking_program_id != NO_STAKING_PROGRAM_ID:
+                user_params.staking_program_id = NO_STAKING_PROGRAM_ID
+                changed = True
+        if changed:
+            svc.store()
+            updated.append(svc.service_config_id)
+    return updated
 
 
 def rename_source_for_rollback(src: OperateStore) -> Path:

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -33,6 +33,7 @@ import argparse
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (
@@ -48,6 +49,7 @@ from typing import (
     Type,
 )
 
+from operate.constants import ZERO_ADDRESS
 from operate.operate_types import Chain, OnChainState
 from operate.quickstart.utils import (
     print_section,
@@ -55,6 +57,7 @@ from operate.quickstart.utils import (
     wei_to_token,
 )
 from operate.services.service import Service
+from operate.utils.gnosis import get_asset_balance
 
 # Programming bugs we DO NOT want wrapped as `_Unmigratable("NFT transfer
 # failed: ...")`. Letting these propagate surfaces the real fault (with a
@@ -101,6 +104,155 @@ def _wrap_step_failure(
     _reraise_if_programming_bug(exc)
     return _Unmigratable(
         service_id=sid, chain=chain, reason=f"{prefix}: {exc}.",
+    )
+
+
+# Poll cadence for `_wait_for_native_funds`. Five seconds matches the
+# olas-operate-middleware `ask_funds_in_address` UX (run_service.py:597)
+# closely enough for an interactive migration script while staying gentle
+# on RPC providers — Safe deployment is a one-shot, not a hot loop.
+_FUNDS_POLL_INTERVAL_SECONDS = 5
+
+
+def _is_insufficient_funds_error(exc: BaseException) -> bool:
+    """Detect the middleware's "no funds" failure so we can wait for the
+    user to top up instead of marking the service un-migratable.
+
+    olas-operate-middleware raises a plain `RuntimeError` (no dedicated
+    exception class) when an EOA can't pay gas — message-matching is the
+    only available signal. We tolerate the two known phrasings and fall
+    through to the generic `_Unmigratable` path on anything else, so a
+    new shape from the middleware degrades to the prior behaviour rather
+    than looping forever on an unrelated error.
+    """
+    msg = str(exc).lower()
+    return (
+        "does not have any funds" in msg
+        or "insufficient funds" in msg
+    )
+
+
+def _wait_for_native_funds(
+    *,
+    ledger_api: Any,
+    address: str,
+    chain_str: str,
+    recipient_name: str,
+    log_indent: str = "    ",
+) -> None:
+    """Block until `address` native balance increases on `chain_str`.
+
+    Mirrors `ask_funds_in_address` from olas-operate-middleware
+    (run_service.py:597). We can't compute the exact required balance
+    for the next on-chain op cheaply (gas price varies, and the
+    middleware doesn't expose it), so we wait for ANY balance increase
+    and let the caller re-attempt. `_retry_on_funds_shortage`'s outer
+    loop is the source of truth: if more funds are still needed, the
+    next attempt will fail and re-enter this wait.
+    """
+    current = get_asset_balance(ledger_api, ZERO_ADDRESS, address)
+    info(
+        f"{log_indent}[{chain_str}] {recipient_name} {address} needs "
+        f"native funds to make migration transactions (current balance: "
+        f"{wei_to_token(current, chain_str, ZERO_ADDRESS)})."
+    )
+    info(
+        f"{log_indent}[{chain_str}] Please transfer some native funds to "
+        f"{address}; this run will continue automatically. "
+        "(Ctrl-C to abort.)"
+    )
+    while True:
+        time.sleep(_FUNDS_POLL_INTERVAL_SECONDS)
+        # RPC outages mid-wait must not crash the migration with a
+        # confusing trace — the user may have already started the
+        # top-up tx. Warn and keep polling; the next poll will see the
+        # arrival once the RPC recovers.
+        try:
+            new = get_asset_balance(ledger_api, ZERO_ADDRESS, address)
+        except Exception as exc:  # pylint: disable=broad-except
+            _reraise_if_programming_bug(exc)
+            warn(
+                f"{log_indent}[{chain_str}] balance read failed "
+                f"({exc}); will retry in {_FUNDS_POLL_INTERVAL_SECONDS}s."
+            )
+            continue
+        if new > current:
+            delta = new - current
+            info(
+                f"{log_indent}[{chain_str}] Detected "
+                f"{wei_to_token(delta, chain_str, ZERO_ADDRESS)} arrived; "
+                "retrying."
+            )
+            return
+
+
+def _retry_on_funds_shortage(
+    fn: Callable[[], Any],
+    *,
+    ledger_api: Any,
+    address: str,
+    chain_str: str,
+    recipient_name: str,
+    log_indent: str = "    ",
+) -> Any:
+    """Run `fn`, blocking on insufficient-funds errors with a
+    wait-and-retry loop against `address`.
+
+    Used at the four signing sites where the middleware actually
+    propagates funds errors: `_step_terminate`, `_step_transfer_nft`,
+    `_step_swap_service_safe_owner`, and the two `pearl_wallet.create_safe`
+    calls (via `_create_pearl_safe_with_funds_wait`). Drain is NOT
+    wrapped — middleware's drain swallows per-asset errors internally,
+    so the wait would never engage; see `_drain_master` for the rationale.
+
+    Non-funds errors and programming bugs propagate; the caller wraps
+    those with the right granularity (per-service vs per-chain).
+    """
+    while True:
+        try:
+            return fn()
+        except Exception as exc:  # pylint: disable=broad-except
+            _reraise_if_programming_bug(exc)
+            if not _is_insufficient_funds_error(exc):
+                raise
+            warn(
+                f"{log_indent}{recipient_name} {address} has insufficient "
+                f"funds on {chain_str}: {exc}"
+            )
+            _wait_for_native_funds(
+                ledger_api=ledger_api,
+                address=address,
+                chain_str=chain_str,
+                recipient_name=recipient_name,
+                log_indent=log_indent,
+            )
+
+
+def _create_pearl_safe_with_funds_wait(
+    *,
+    pearl_wallet: Any,
+    chain: Any,
+    chain_str: str,
+    rpc: str,
+    ledger_api: Any,
+    log_indent: str = "    ",
+) -> None:
+    """Create the Pearl master Safe on `chain`, blocking on insufficient
+    funds with a wait-and-retry loop.
+
+    On non-funds errors the original exception is re-raised so the caller
+    can wrap it with the right granularity (`_Unmigratable` per-service
+    on the migration path, `_DrainFailure` on the drain path). Programming
+    bugs propagate as real tracebacks.
+    """
+    info(f"{log_indent}Pearl has no master Safe on {chain_str}; creating one.")
+    _retry_on_funds_shortage(
+        lambda: pearl_wallet.create_safe(chain=chain, rpc=rpc),
+        ledger_api=ledger_api,
+        address=pearl_wallet.address,
+        chain_str=chain_str,
+        recipient_name="Pearl master EOA",
+        log_indent=log_indent,
     )
 
 
@@ -693,6 +845,7 @@ def _step_terminate(
     *, manager: "ServiceManager", service: "Service", sid: str, chain_str: str,
     ensure_signable,                            # callable[[], None]
     on_chain_state_cls: OnChainState,
+    ledger_api: Any, qs_address: str,
 ) -> None:
     """Move on-chain to PRE_REGISTRATION (idempotent).
 
@@ -705,8 +858,12 @@ def _step_terminate(
         return
     ensure_signable()
     try:
-        manager.terminate_service_on_chain_from_safe(
-            service_config_id=sid, chain=chain_str,
+        _retry_on_funds_shortage(
+            lambda: manager.terminate_service_on_chain_from_safe(
+                service_config_id=sid, chain=chain_str,
+            ),
+            ledger_api=ledger_api, address=qs_address, chain_str=chain_str,
+            recipient_name="Quickstart master EOA",
         )
     except Exception as exc:  # pylint: disable=broad-except
         raise _wrap_step_failure(
@@ -772,12 +929,16 @@ def _step_transfer_nft(
     ensure_signable()
     info(f"  transferring service NFT {token_id} {qs_master_safe} -> {pearl_master_safe}")
     try:
-        transfer_service_nft(
-            ledger_api=ledger_api, crypto=qs_wallet.crypto,
-            service_registry_address=registry_addr,
-            qs_master_safe=qs_master_safe,
-            pearl_master_safe=pearl_master_safe,
-            service_id=token_id,
+        _retry_on_funds_shortage(
+            lambda: transfer_service_nft(
+                ledger_api=ledger_api, crypto=qs_wallet.crypto,
+                service_registry_address=registry_addr,
+                qs_master_safe=qs_master_safe,
+                pearl_master_safe=pearl_master_safe,
+                service_id=token_id,
+            ),
+            ledger_api=ledger_api, address=qs_wallet.address,
+            chain_str=chain_str, recipient_name="Quickstart master EOA",
         )
     except PostConditionUnknown as exc:
         # Distinct from "inner reverted": tx submitted, but the post-tx
@@ -833,10 +994,14 @@ def _step_swap_service_safe_owner(
     ensure_signable()
     info(f"  swapping owner on service Safe {service_safe}")
     try:
-        swap_service_safe_owner(
-            ledger_api=ledger_api, crypto=qs_wallet.crypto,
-            service_safe=service_safe,
-            old_owner=qs_master_safe, new_owner=pearl_master_safe,
+        _retry_on_funds_shortage(
+            lambda: swap_service_safe_owner(
+                ledger_api=ledger_api, crypto=qs_wallet.crypto,
+                service_safe=service_safe,
+                old_owner=qs_master_safe, new_owner=pearl_master_safe,
+            ),
+            ledger_api=ledger_api, address=qs_wallet.address,
+            chain_str=chain_str, recipient_name="Quickstart master EOA",
         )
     except PostConditionUnknown as exc:
         # State is INDETERMINATE — execTransaction submitted but the
@@ -941,12 +1106,19 @@ def _migrate_one_service(
             )
         # Ensure Pearl has a master Safe on this chain. `create_safe` is
         # the same factory that bootstraps Pearl on a new chain — required
-        # before the Safe owner swap can name a real `new_owner`.
+        # before the Safe owner swap can name a real `new_owner`. Funding
+        # is the common failure here (Pearl's master EOA is fresh): block
+        # and let the user top up rather than abort the whole service.
         if chain not in pearl_wallet.safes:
-            info(f"    Pearl has no master Safe on {chain_str}; creating one.")
             try:
-                pearl_wallet.create_safe(
-                    chain=chain, rpc=chain_config.ledger_config.rpc,
+                _create_pearl_safe_with_funds_wait(
+                    pearl_wallet=pearl_wallet,
+                    chain=chain,
+                    chain_str=chain_str,
+                    rpc=chain_config.ledger_config.rpc,
+                    ledger_api=pearl_wallet.ledger_api(
+                        chain=chain, rpc=chain_config.ledger_config.rpc,
+                    ),
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 _reraise_if_programming_bug(exc)
@@ -1010,6 +1182,7 @@ def _migrate_one_service(
         _step_terminate(
             manager=manager, service=service, sid=sid, chain_str=chain_str,
             ensure_signable=_ensure_signable, on_chain_state_cls=OnChainState,
+            ledger_api=_ledger_api(), qs_address=qs_wallet.address,
         )
         _step_transfer_nft(
             ledger_api=_ledger_api(), qs_wallet=qs_wallet,
@@ -1085,9 +1258,15 @@ def _drain_master(
                            "drain into.",
                 ))
                 continue
-            info(f"  Pearl has no master Safe on {chain.name}; creating one.")
             try:
-                pearl_wallet.create_safe(chain=chain, rpc=rpc)
+                _create_pearl_safe_with_funds_wait(
+                    pearl_wallet=pearl_wallet,
+                    chain=chain,
+                    chain_str=chain.name,
+                    rpc=rpc,
+                    ledger_api=pearl_wallet.ledger_api(chain=chain, rpc=rpc),
+                    log_indent="  ",
+                )
             except Exception as exc:  # pylint: disable=broad-except
                 _reraise_if_programming_bug(exc)
                 warn(f"  could not create Pearl Safe on {chain.name}: {exc}")
@@ -1099,6 +1278,17 @@ def _drain_master(
                 ))
                 continue
 
+        # NOTE: `qs_wallet.drain` is NOT wrapped in `_retry_on_funds_shortage`.
+        # Middleware's drain catches per-asset transfer exceptions
+        # internally (`except Exception: logger.warning(...)` around the
+        # per-asset `self.transfer` call in master.py's `MasterWallet.drain`)
+        # and continues to the next asset — funds shortages never propagate
+        # out of `drain`. Wrapping it here would be dead code for the
+        # funds-wait case. If the qs EOA runs out of gas mid-drain, drain
+        # logs warnings, returns whatever moved before the failure(s), and
+        # the user sees a partial / empty `moved` dict. They can re-run
+        # after topping up; the drain is idempotent (per-asset balance
+        # check before each transfer).
         # Master Safe -> Pearl master Safe (Pearl Safe receives ERC20s + native).
         info(f"  [{chain.name}] master Safe -> Pearl master Safe ({pearl_wallet.safes[chain]})")
         try:

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -35,7 +35,18 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    NoReturn,
+    Optional,
+    Tuple,
+    Type,
+)
 
 from operate.operate_types import Chain, OnChainState
 from operate.quickstart.utils import (
@@ -295,6 +306,56 @@ def _load_wallet(
 
 
 # ---------------------------------------------------------------------------
+# Shared cleanup helper (used by both Mode A and Mode B)
+# ---------------------------------------------------------------------------
+
+def _ensure_containers_stopped(
+    on_failure: Callable[[str], NoReturn],
+) -> List[str]:
+    """Force-remove known quickstart containers and re-probe to confirm.
+
+    Both modes need the same three-step guarantee before touching the
+    qs `.operate/`:
+      1. `force_remove_known_containers()` — best-effort `docker rm -f`.
+      2. Re-probe via `docker_quickstart_containers()` — catches the
+         case where step 1 returned cleanly but the daemon refused the
+         rm with a non-zero exit (the old `check=False` behavior; now
+         tightened to `check=True` but the re-probe is still the
+         belt-and-braces guard against future regressions).
+      3. Surface any "still running" via `on_failure`.
+
+    `on_failure` MUST NOT return — it must either raise or
+    `sys.exit`. Callers decide the failure shape:
+      * Mode A passes `fatal` (global, no aggregation possible).
+      * Mode B passes a closure that raises `_Unmigratable(service_id=...)`
+        so the orchestrator can keep migrating other services.
+
+    Returns the list of containers that step 1 force-removed (may be
+    empty). Callers can log this; failure paths never return so the
+    caller doesn't need to check.
+    """
+    try:
+        leftovers = force_remove_known_containers()
+    except (subprocess.TimeoutExpired, RuntimeError) as exc:
+        on_failure(
+            f"could not confirm containers are stopped: {exc}. "
+            "Stop the running deployment manually (`docker ps`, "
+            "`docker rm -f`) and re-run."
+        )
+    try:
+        remaining = docker_quickstart_containers()
+    except RuntimeError as exc:
+        on_failure(f"could not verify containers stopped: {exc}.")
+    if remaining:
+        on_failure(
+            f"quickstart containers still running after cleanup: "
+            f"{remaining}. Stop them manually (`docker ps`, "
+            "`docker rm -f`) before re-running."
+        )
+    return leftovers
+
+
+# ---------------------------------------------------------------------------
 # Mode A — fresh copy
 # ---------------------------------------------------------------------------
 
@@ -325,16 +386,13 @@ def _run_mode_a(disc: Discovery, dry_run: bool) -> MigrationOutcome:
         info(f"[dry-run] Would copy {disc.quickstart.root} -> {disc.pearl.root}")
         return MigrationOutcome()
 
-    # Best-effort: stop the deployment(s) so containers don't conflict later.
-    # Mode A has no per-service aggregation, so an unstoppable deployment
-    # is a `fatal()` — copying `.operate/` while the daemon is still
-    # writing to it would corrupt the migration.
-    try:
-        leftovers = force_remove_known_containers()
-    except (subprocess.TimeoutExpired, RuntimeError) as exc:
-        fatal(f"Could not stop running deployment: {exc}. "
-              "Stop the running deployment manually (`docker ps`, "
-              "`docker rm -f`) and re-run.")
+    # Stop and verify any quickstart containers are gone. Mode A has no
+    # per-service aggregation, so failures escalate to `fatal()` — copying
+    # `.operate/` while the daemon is still writing to `persistent_data/`
+    # or `deployment/nodes/.../{config,data}/` would corrupt the migration,
+    # and the subsequent `rename_source_for_rollback` would make it
+    # unrecoverable.
+    leftovers = _ensure_containers_stopped(on_failure=fatal)
     if leftovers:
         info(f"Removed leftover containers: {', '.join(leftovers)}")
 
@@ -840,37 +898,15 @@ def _migrate_one_service(
             # the on-chain branch.
             _reraise_if_programming_bug(exc)
             warn(f"stop_service via middleware failed: {exc}; trying force cleanup.")
-    # `force_remove_known_containers` raises `subprocess.TimeoutExpired` on
-    # docker daemon hang. `docker_quickstart_containers` raises
-    # `RuntimeError` if `docker ps` itself fails (permission denied on
-    # /var/run/docker.sock, daemon down, etc.). Convert both to a
-    # per-service `_Unmigratable` — proceeding to NFT transfer with
-    # containers possibly still signing with the agent key would race.
-    try:
-        force_remove_known_containers()
-    except (subprocess.TimeoutExpired, RuntimeError) as exc:
-        raise _Unmigratable(
-            service_id=sid, chain=None,
-            reason=f"could not confirm containers are stopped: {exc}. "
-                   "Stop the running deployment manually (`docker ps`, "
-                   "`docker rm -f`) and re-run.",
-        )
-    # Re-probe so a `force_remove_known_containers()` that returned
-    # cleanly but didn't actually remove the containers (e.g. docker
-    # daemon refused the rm with non-zero exit) still surfaces.
-    try:
-        remaining = docker_quickstart_containers()
-    except RuntimeError as exc:
-        raise _Unmigratable(
-            service_id=sid, chain=None,
-            reason=f"could not verify containers stopped: {exc}.",
-        )
-    if remaining:
-        raise _Unmigratable(
-            service_id=sid, chain=None,
-            reason=f"quickstart containers still running after cleanup: "
-                   f"{remaining}. Stop them manually before re-running.",
-        )
+    # Per-service variant of the global stop-and-verify: convert any
+    # cleanup failure into `_Unmigratable(service_id=...)` so the
+    # orchestrator can keep migrating other services. Proceeding to NFT
+    # transfer with containers possibly still signing with the agent key
+    # would race.
+    def _bail(reason: str) -> NoReturn:
+        raise _Unmigratable(service_id=sid, chain=None, reason=reason)
+
+    _ensure_containers_stopped(on_failure=_bail)
 
     # ---- per-chain on-chain operations --------------------------------------
     for chain_str, chain_config in service.chain_configs.items():

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -130,6 +130,7 @@ from scripts.pearl_migration.stop import (
     force_remove_known_containers,
     stop_via_middleware,
 )
+from scripts.pearl_migration.wallet import align_quickstart_password
 
 
 # ---------------------------------------------------------------------------
@@ -465,7 +466,29 @@ def _run_mode_b(
 
     # ---- load BOTH master wallets up front -----------------------------------
     qs_app, qs_wallet = _load_wallet(disc.quickstart, "quickstart")
-    _, pearl_wallet = _load_wallet(disc.pearl, "Pearl")
+    pearl_app, pearl_wallet = _load_wallet(disc.pearl, "Pearl")
+
+    # ---- align master passwords if they differ -------------------------------
+    # Pearl's keys manager will use Pearl's password to decrypt every agent
+    # key it inherits from us. If qs and Pearl were initialised with
+    # different passwords, the agent keys must be re-encrypted with Pearl's
+    # password BEFORE merging — otherwise the first deploy from Pearl fails
+    # with `DecryptError: Decrypt error! Bad password?`.
+    if qs_app.password != pearl_app.password:
+        print_section("ALIGNING QUICKSTART PASSWORD")
+        info(
+            "The quickstart and Pearl master passwords differ. Before "
+            "merging, the quickstart's master keyfile and every agent key "
+            "under `keys/` will be re-encrypted with Pearl's password. The "
+            "original keyfiles are kept as `.bak` siblings."
+        )
+        if not yes_no("Proceed with re-encryption?", default=True):
+            fatal("Migration aborted by user; nothing on-chain has changed.")
+        align_quickstart_password(
+            qs_app=qs_app,
+            qs_wallet=qs_wallet,
+            new_password=pearl_app.password,
+        )
 
     fix_root_ownership(disc.quickstart)
 

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -1,0 +1,1134 @@
+#!/usr/bin/env python3
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# ------------------------------------------------------------------------------
+
+"""Migrate quickstart `.operate/` to Pearl's `~/.operate/`.
+
+Two modes (auto-detected):
+
+* **Fresh copy** — `~/.operate` does not exist (or is empty / has no Pearl
+  master wallet). The whole `.operate` is copied over. Pearl will pick it up
+  on first launch and re-use the same master wallet.
+
+* **Merge** — `~/.operate` already has a Pearl master wallet. Per service we
+  unstake on-chain, transfer the service NFT from the quickstart master Safe
+  to the Pearl master Safe, swap the service Safe owner, and copy the service
+  files. After all services succeed, the quickstart master Safe + EOA balances
+  are drained into Pearl's master Safe + EOA. If any service can't be unstaked
+  yet, drains are skipped so funds remain available for a later attempt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Type
+
+from operate.operate_types import Chain, OnChainState
+from operate.quickstart.utils import (
+    print_section,
+    print_title,
+    wei_to_token,
+)
+from operate.services.service import Service
+
+# Programming bugs we DO NOT want wrapped as `_Unmigratable("NFT transfer
+# failed: ...")`. Letting these propagate surfaces the real fault (with a
+# real traceback) instead of disguising it as a chain-side issue. Add to
+# this list cautiously — anything in it MUST NEVER originate from a normal
+# RPC / on-chain failure path. Notable omissions:
+#   * `KeyError` / `LookupError`: web3 + middleware code raises these on
+#     missing chain metadata (e.g. `CONTRACTS[chain]`, `tx_receipt["status"]`,
+#     ABI lookups). One bad chain shouldn't crash the whole multi-service
+#     batch — let it become a per-service `_Unmigratable` instead.
+_PROGRAMMING_BUGS: Tuple[Type[BaseException], ...] = (
+    TypeError,
+    AttributeError,
+    NameError,
+    ImportError,
+)
+
+
+def _reraise_if_programming_bug(exc: BaseException) -> None:
+    """Re-raise `exc` if it's a programming bug.
+
+    Use at every `except Exception` site that wraps the exception into
+    a chain-side failure (`_Unmigratable`, `_DrainFailure`, or a `warn(...)`
+    downgrade). Without it, a `TypeError` / `AttributeError` introduced
+    by a middleware refactor would be silently logged as "RPC failed,
+    retry" and the user would chase the wrong root cause.
+    """
+    if isinstance(exc, _PROGRAMMING_BUGS):
+        raise exc
+
+
+def _wrap_step_failure(
+    *, sid: str, chain: str, prefix: str, exc: BaseException,
+) -> "_Unmigratable":
+    """Build the `_Unmigratable` for a step's `except` block.
+
+    Re-raises members of `_PROGRAMMING_BUGS` (TypeError, AttributeError,
+    NameError, ImportError) so they surface as real tracebacks rather
+    than getting smuggled into the user's "chain failed" summary.
+    Everything else — including `KeyError`/`LookupError` raised by web3
+    or middleware on missing chain metadata — gets wrapped so a single
+    bad chain doesn't crash the whole multi-service batch.
+    """
+    _reraise_if_programming_bug(exc)
+    return _Unmigratable(
+        service_id=sid, chain=chain, reason=f"{prefix}: {exc}.",
+    )
+
+
+from scripts.pearl_migration.detect import (
+    Discovery,
+    Mode,
+    OperateStore,
+    discover,
+)
+
+if TYPE_CHECKING:
+    from operate.cli import OperateApp
+    from operate.services.manage import ServiceManager
+    from operate.services.service import Service
+    from operate.operate_types import Chain
+    from operate.wallet.master import MasterWallet
+from scripts.pearl_migration.filesystem import (
+    fix_root_ownership,
+    fresh_copy_store,
+    merge_service,
+    rename_source_for_rollback,
+)
+from scripts.pearl_migration.prompts import (
+    ask_password_validating,
+    fatal,
+    info,
+    warn,
+    yes_no,
+)
+from scripts.pearl_migration.status import (
+    docker_quickstart_containers,
+    pearl_daemon_running,
+    safe_owners,
+    safe_threshold,
+    service_nft_owner,
+)
+from scripts.pearl_migration.stop import (
+    force_remove_known_containers,
+    stop_via_middleware,
+)
+
+
+# ---------------------------------------------------------------------------
+# args
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="migrate_to_pearl.py",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "config_path",
+        nargs="?",
+        help=(
+            "Optional path to a quickstart agent config JSON. "
+            "If given, only the matching service is migrated. "
+            "If omitted, the script lists all services found and asks."
+        ),
+    )
+    p.add_argument(
+        "--quickstart-home",
+        type=Path,
+        default=None,
+        help="Override quickstart `.operate` location (default: ./.operate).",
+    )
+    p.add_argument(
+        "--pearl-home",
+        type=Path,
+        default=None,
+        help="Override Pearl `.operate` location (default: ~/.operate).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover and report only; do not stop services, transfer, or copy anything.",
+    )
+    return p.parse_args(argv)
+
+
+# ---------------------------------------------------------------------------
+# Service selection
+# ---------------------------------------------------------------------------
+
+def _select_services(
+    qs: OperateStore,
+    config_path: Optional[str],
+) -> List[Service]:
+    services = qs.services()
+    if not services:
+        fatal(f"No services found under {qs.services_dir}.")
+
+    if config_path is None:
+        if len(services) == 1:
+            return services
+        print()
+        print("Multiple services found in this quickstart:")
+        for idx, svc in enumerate(services, 1):
+            print(f"  {idx}) {svc.name}  ({svc.service_config_id})")
+        print(f"  {len(services) + 1}) all of the above")
+        while True:
+            try:
+                raw = input("Select [1-{}]: ".format(len(services) + 1)).strip()
+            except EOFError:
+                # Piped/closed stdin (CI, automation) — re-prompting forever
+                # would hang. Surface as a clean fatal instead of a raw
+                # `EOFError: EOF when reading a line` traceback.
+                fatal("No selection provided (stdin closed). Re-run with "
+                      "`--quickstart-config <path>` or attach a tty.")
+            if raw.isdigit():
+                n = int(raw)
+                if 1 <= n <= len(services):
+                    return [services[n - 1]]
+                if n == len(services) + 1:
+                    return services
+            warn(f"Invalid selection '{raw}'. Enter a number 1-{len(services) + 1}.")
+
+    # config_path given: match by 'name' or 'hash'
+    import json
+    try:
+        cfg = json.loads(Path(config_path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        fatal(f"Cannot read config {config_path}: {exc}")
+    name = cfg.get("name")
+    hash_ = cfg.get("hash")
+    matches = [s for s in services if s.name == name]
+    if not matches and hash_:
+        matches = [s for s in services if s.hash == hash_]
+    if not matches:
+        fatal(f"No service in {qs.services_dir} matches config '{config_path}'.")
+    return matches
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+
+def _preflight(disc: Discovery) -> None:
+    info(f"Quickstart .operate: {disc.quickstart.root}")
+    info(f"Pearl .operate:      {disc.pearl.root}")
+    info(f"Mode:                {disc.mode.value}")
+
+    if disc.mode == Mode.NOOP:
+        print()
+        print("Quickstart's .operate is already at Pearl's expected location.")
+        print("Nothing to migrate. Start Pearl and enter your master password.")
+        sys.exit(0)
+
+    if pearl_daemon_running():
+        fatal(
+            "Pearl appears to be running (port 8765 is in use). "
+            "Quit Pearl before re-running this script."
+        )
+
+    leftovers = docker_quickstart_containers()
+    if leftovers:
+        warn(
+            "Quickstart docker containers detected: "
+            + ", ".join(leftovers)
+            + ". They will be stopped during migration."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wallet loading
+# ---------------------------------------------------------------------------
+
+def _load_wallet(
+    store: OperateStore, label: str,
+) -> Tuple["OperateApp", "MasterWallet"]:
+    """Prompt for the password for `store` and return (OperateApp, wallet).
+
+    Validates the password against a lightweight `MasterWalletManager`
+    BEFORE building the full `OperateApp` for the store. `OperateApp`
+    instantiation triggers middleware migrations and a version-bump
+    backup of the `.operate` dir; we want neither to happen against
+    Pearl's store on a typo'd password.
+    """
+    from operate.operate_types import LedgerType
+    from operate.wallet.master import MasterWalletManager
+
+    if not store.has_master_wallet():
+        fatal(f"No master wallet at {store.wallets_dir}; cannot continue.")
+
+    print()
+    print(f"Enter the {label} master password:")
+    # Lightweight validator — touches only `wallets/`, doesn't run migrations.
+    validator = MasterWalletManager(path=store.wallets_dir)
+    pw = ask_password_validating(
+        prompt=f"  {label} password: ",
+        validate=validator.is_password_valid,
+    )
+    if pw is None:
+        fatal(f"Could not unlock {label} master wallet.")
+
+    # Password good; now safe to build the full app (with migrations).
+    app = store.operate_app(password=pw)
+    wallet = app.wallet_manager.load(LedgerType.ETHEREUM)
+    return app, wallet
+
+
+# ---------------------------------------------------------------------------
+# Mode A — fresh copy
+# ---------------------------------------------------------------------------
+
+def _run_mode_a(disc: Discovery, dry_run: bool) -> MigrationOutcome:
+    """Run the fresh-copy mode and return an empty `MigrationOutcome`
+    (which is `is_complete=True` by construction) so the caller can
+    plumb a uniform `MigrationOutcome` through `_final_prompt`.
+
+    Mode A has no per-service / per-chain partial-failure state: any
+    `OSError` / `shutil.Error` from the copy or rename callees propagates
+    uncaught and aborts the run. There's no `try/except` here because
+    there's no recovery to attempt — a half-copy is worse than no copy.
+    """
+    print_section("FRESH COPY")
+    info("Pearl's `.operate` does not yet exist (or is empty). Doing a full copy.")
+
+    # If Pearl dir exists but no wallet, back it up so the copy is clean.
+    if disc.pearl.root.exists():
+        from scripts.pearl_migration.prompts import backup_suffix as _bs
+        bak = disc.pearl.root.with_name(f"{disc.pearl.root.name}.bak.{_bs()}")
+        if dry_run:
+            info(f"[dry-run] Would back up empty Pearl dir to {bak}.")
+        else:
+            disc.pearl.root.rename(bak)
+            info(f"Backed up empty Pearl dir to {bak}.")
+
+    if dry_run:
+        info(f"[dry-run] Would copy {disc.quickstart.root} -> {disc.pearl.root}")
+        return MigrationOutcome()
+
+    # Best-effort: stop the deployment(s) so containers don't conflict later.
+    # Mode A has no per-service aggregation, so an unstoppable deployment
+    # is a `fatal()` — copying `.operate/` while the daemon is still
+    # writing to it would corrupt the migration.
+    try:
+        leftovers = force_remove_known_containers()
+    except (subprocess.TimeoutExpired, RuntimeError) as exc:
+        fatal(f"Could not stop running deployment: {exc}. "
+              "Stop the running deployment manually (`docker ps`, "
+              "`docker rm -f`) and re-run.")
+    if leftovers:
+        info(f"Removed leftover containers: {', '.join(leftovers)}")
+
+    # Fix root-owned persistent_data BEFORE the copy so the copy is owned by us.
+    fix_root_ownership(disc.quickstart)
+
+    fresh_copy_store(disc.quickstart, disc.pearl.root)
+    print()
+    info("Renaming source `.operate/` so a re-run won't pick it up.")
+    rename_source_for_rollback(disc.quickstart)
+    return MigrationOutcome()
+
+
+# ---------------------------------------------------------------------------
+# Mode B — merge
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _Unmigratable(Exception):
+    """Raised when a single service can't proceed but others might.
+
+    Carries structured context so the orchestrator can print a useful
+    "what was left behind" summary at the end without parsing strings.
+
+    `frozen=True` because:
+      * `MigrationOutcome` is `frozen=True` and contains
+        `Tuple[_Unmigratable, ...]`; if `_Unmigratable` were unhashable
+        the outcome's auto-generated `__hash__` would fail at runtime.
+      * Exceptions shouldn't be mutated after raise anyway.
+
+    `__post_init__` forwards all three fields to `Exception.__init__` so
+    `traceback.format_exception` and any code reading `exc.args` sees
+    the structured payload — the dataclass-synthesized `__init__`
+    doesn't populate `args` automatically.
+
+    `__reduce__` is explicit so `multiprocessing` / `concurrent.futures`
+    serialization round-trips correctly. Default `Exception.__reduce__`
+    would call `cls(*self.args)` which only works as long as `args`
+    matches our positional `__init__` signature — keeping both aligned
+    is the contract.
+    """
+
+    service_id: str
+    chain: Optional[str]
+    reason: str
+
+    def __post_init__(self) -> None:
+        super().__init__(self.service_id, self.chain, self.reason)
+
+    def __reduce__(self) -> tuple:
+        return (self.__class__, (self.service_id, self.chain, self.reason))
+
+    def __str__(self) -> str:  # pragma: no cover - trivial formatter
+        where = f" on {self.chain}" if self.chain else ""
+        return f"{self.service_id}{where}: {self.reason}"
+
+
+DrainSourceKind = Literal["Safe", "EOA", "Safe+EOA"]
+
+
+@dataclass(frozen=True)
+class _DrainFailure:
+    """One per-source drain that didn't complete.
+
+    `chain` is the middleware `Chain` enum (not a stringified name) so the
+    summary table sorts and groups consistently with everything else that
+    talks chains. `source_kind` is constrained at the type level.
+    """
+
+    chain: "Chain"
+    source_kind: DrainSourceKind
+    source_address: str
+    reason: str
+
+    @property
+    def chain_name(self) -> str:
+        # Display helper: the summary template formats by chain name, not enum repr.
+        return self.chain.name
+
+
+@dataclass(frozen=True)
+class MigrationOutcome:
+    """Aggregate result of a Mode B run.
+
+    One value object propagates from `_run_mode_b` through `_print_migration_summary`
+    and `_final_prompt`, replacing the prior `(bool, list, list, int)` data clump.
+    """
+
+    migrated: Tuple[Service, ...] = ()
+    unmigratable: Tuple["_Unmigratable", ...] = ()
+    drain_failures: Tuple[_DrainFailure, ...] = ()
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.unmigratable and not self.drain_failures
+
+    @property
+    def migrated_count(self) -> int:
+        return len(self.migrated)
+
+
+def _run_mode_b(
+    disc: Discovery,
+    services: List[Service],
+    config_path: Optional[str],
+    dry_run: bool,
+) -> MigrationOutcome:
+    """Returns the structured `MigrationOutcome`. `outcome.is_complete` False
+    suppresses the source-`.operate/` rename so the user can resume."""
+    print_section("MERGE")
+    info(f"Will migrate {len(services)} service(s): " + ", ".join(s.name for s in services))
+
+    if dry_run:
+        info("[dry-run] Stopping at discovery; no on-chain or filesystem actions taken.")
+        return MigrationOutcome()
+
+    # If `OperateStore.services()` dropped any malformed configs we MUST NOT
+    # drain — the dropped service's NFT/Safe would be orphaned with empty
+    # master wallets behind. Refuse before touching anything.
+    failed_loads = disc.quickstart.failed_services()
+    if failed_loads:
+        for path, exc in failed_loads:
+            warn(f"  service config could not be loaded: {path.name} ({exc!r})")
+        fatal(
+            "Refusing to migrate while one or more service configs failed to load — "
+            "the master wallet drain would orphan those services. Resolve the "
+            "config errors above and re-run.",
+        )
+
+    # ---- load BOTH master wallets up front -----------------------------------
+    qs_app, qs_wallet = _load_wallet(disc.quickstart, "quickstart")
+    _, pearl_wallet = _load_wallet(disc.pearl, "Pearl")
+
+    fix_root_ownership(disc.quickstart)
+
+    unmigratable: List[_Unmigratable] = []
+    migrated: List[Service] = []
+    # Collected from each migrated service's chain_configs; passed to the
+    # drain step so Pearl Safes can be created on chains where Pearl
+    # didn't have one yet (using the same RPC the migration was driven by).
+    chain_rpcs: dict = {}
+
+    from operate.operate_types import Chain as _Chain
+
+    for svc in services:
+        print_section(f"Migrating service: {svc.name}  ({svc.service_config_id})")
+        # Snapshot the service's chain RPCs up front — used by the drain
+        # step even if the per-service migration partially fails. If two
+        # services declare different RPCs for the same chain, the first
+        # wins (deterministic) but we warn so the user can investigate
+        # rather than silently inheriting one over the other.
+        for chain_str, chain_config in svc.chain_configs.items():
+            chain_key = _Chain(chain_str)
+            new_rpc = chain_config.ledger_config.rpc
+            existing_rpc = chain_rpcs.get(chain_key)
+            if existing_rpc is None:
+                chain_rpcs[chain_key] = new_rpc
+            elif existing_rpc != new_rpc:
+                warn(
+                    f"  service {svc.name} declares a different RPC for "
+                    f"{chain_str} than a previous service "
+                    f"({existing_rpc!r} vs {new_rpc!r}); keeping the first "
+                    "for the master-wallet drain step.",
+                )
+
+        try:
+            _migrate_one_service(
+                svc=svc,
+                qs_app=qs_app,
+                qs_wallet=qs_wallet,
+                pearl_wallet=pearl_wallet,
+                config_path=config_path,
+            )
+        except _Unmigratable as exc:
+            warn(f"Skipping service {svc.name}: {exc}")
+            unmigratable.append(exc)
+            continue
+        # Filesystem copy runs AFTER on-chain ops have committed. A copy
+        # failure here is the worst-case "half-migrated" state: NFT is
+        # already owned by Pearl Safe + service Safe owner is already
+        # swapped, but the local files haven't moved. Convert to
+        # `_Unmigratable` so it gets aggregated into the outcome and the
+        # user is told exactly what to do — instead of a raw traceback
+        # that aborts the whole batch, skips drain + rename, and leaves
+        # them with no idea the on-chain side is committed.
+        try:
+            merge_service(service=svc, src=disc.quickstart, dest=disc.pearl)
+        except (OSError, shutil.Error) as exc:
+            warn(f"Skipping service {svc.name}: filesystem copy failed: {exc}")
+            unmigratable.append(_Unmigratable(
+                service_id=svc.service_config_id, chain=None,
+                reason=(
+                    f"on-chain migration committed but filesystem copy "
+                    f"failed: {exc}. Manually copy "
+                    f"`services/{svc.service_config_id}/` and the agent "
+                    f"keys (under `keys/`) from {disc.quickstart.root} to "
+                    f"{disc.pearl.root} before launching Pearl."
+                ),
+            ))
+            continue
+        migrated.append(svc)
+
+    # ---- final master-wallet drains ------------------------------------------
+    drain_failures: List[_DrainFailure] = []
+    if unmigratable:
+        print()
+        warn(
+            "One or more services could not be migrated. "
+            "Skipping the master-Safe and master-EOA drains so funds remain "
+            "available for completing those migrations later.",
+        )
+    else:
+        drain_failures = _drain_master(
+            qs_wallet=qs_wallet, pearl_wallet=pearl_wallet,
+            chain_rpcs=chain_rpcs,
+        )
+
+    outcome = MigrationOutcome(
+        migrated=tuple(migrated),
+        unmigratable=tuple(unmigratable),
+        drain_failures=tuple(drain_failures),
+    )
+
+    # ---- final summary -------------------------------------------------------
+    _print_migration_summary(outcome)
+
+    # ---- rename source -------------------------------------------------------
+    # Never rename when the migration is incomplete: the user needs the
+    # source `.operate/` discoverable to resume.
+    if migrated and outcome.is_complete:
+        print()
+        if yes_no(
+            "Rename the source quickstart `.operate/` to keep it as a rollback?",
+            default=True,
+        ):
+            rename_source_for_rollback(disc.quickstart)
+    elif not outcome.is_complete:
+        info(
+            "Source `.operate/` left in place (migration incomplete) — "
+            f"re-run `migrate_to_pearl.sh` from {disc.quickstart.root.parent} "
+            "after addressing the issues above.",
+        )
+
+    return outcome
+
+
+def _print_migration_summary(outcome: MigrationOutcome) -> None:
+    if outcome.is_complete:
+        # Print a positive confirmation so the rename prompt that follows
+        # has context (the user shouldn't be asked "rollback?" with no
+        # preceding "from what?" headline).
+        print_section("Migration summary")
+        info(f"  fully migrated: {outcome.migrated_count} service(s)")
+        return
+    print_section("Migration incomplete — action required")
+    info(f"  fully migrated: {outcome.migrated_count} service(s)")
+    if outcome.unmigratable:
+        warn(f"  un-migrated services: {len(outcome.unmigratable)}")
+        for exc in outcome.unmigratable:
+            warn(f"    - {exc}")
+    if outcome.drain_failures:
+        warn(f"  drain failures: {len(outcome.drain_failures)}")
+        for f in outcome.drain_failures:
+            warn(
+                f"    - [{f.chain_name}] {f.source_kind} {f.source_address}: "
+                f"{f.reason}",
+            )
+        warn(
+            "  Funds may still be present on the quickstart wallet on these "
+            "chains. Re-run after resolving the underlying issue (RPC, gas, "
+            "etc.) to retry the drain.",
+        )
+
+
+def _step_terminate(
+    *, manager: "ServiceManager", service: "Service", sid: str, chain_str: str,
+    ensure_signable,                            # callable[[], None]
+    on_chain_state_cls: OnChainState,
+) -> None:
+    """Move on-chain to PRE_REGISTRATION (idempotent).
+
+    `_get_on_chain_state` is a private middleware method (no public
+    equivalent yet); revisit if/when middleware exposes one.
+    """
+    on_chain_state = manager._get_on_chain_state(service, chain_str)  # noqa: SLF001
+    if on_chain_state == on_chain_state_cls.PRE_REGISTRATION:
+        info("    already in PRE_REGISTRATION; skipping terminate.")
+        return
+    ensure_signable()
+    try:
+        manager.terminate_service_on_chain_from_safe(
+            service_config_id=sid, chain=chain_str,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        raise _wrap_step_failure(
+            sid=sid, chain=chain_str,
+            prefix="could not unstake/terminate; funds left in master "
+                   "Safe/EOA so you can retry",
+            exc=exc,
+        )
+    # Verification read after terminate succeeded. Wrap so a transient
+    # RPC failure here becomes a per-service `_Unmigratable` ("terminated
+    # but unverified") rather than aborting the whole batch with a raw
+    # traceback past `_run_mode_b`'s `except _Unmigratable`.
+    try:
+        on_chain_state = manager._get_on_chain_state(service, chain_str)  # noqa: SLF001
+    except Exception as exc:  # pylint: disable=broad-except
+        raise _wrap_step_failure(
+            sid=sid, chain=chain_str,
+            prefix="terminate succeeded but post-state verification "
+                   "failed (on-chain progressed; re-run will resume from "
+                   "the next step)",
+            exc=exc,
+        )
+    if on_chain_state != on_chain_state_cls.PRE_REGISTRATION:
+        raise _Unmigratable(
+            service_id=sid, chain=chain_str,
+            reason=f"after terminate, service is in state {on_chain_state.name}, "
+                   "expected PRE_REGISTRATION.",
+        )
+
+
+def _step_transfer_nft(
+    *, ledger_api: Any, qs_wallet: Any, registry_addr: str,
+    qs_master_safe: str, pearl_master_safe: str,
+    token_id: int, sid: str, chain_str: str,
+    ensure_signable,
+) -> None:
+    """Transfer the service NFT to Pearl's master Safe (idempotent)."""
+    from scripts.pearl_migration.transfer import transfer_service_nft
+
+    current_owner = service_nft_owner(
+        ledger_api=ledger_api,
+        service_registry_address=registry_addr,
+        service_id=token_id,
+    )
+    if current_owner is None:
+        raise _Unmigratable(
+            service_id=sid, chain=chain_str,
+            reason=f"could not read NFT owner for token {token_id}; "
+                   "RPC error or contract revert.",
+        )
+    if current_owner.lower() == pearl_master_safe.lower():
+        info("    NFT already owned by Pearl master Safe; skipping transfer.")
+        return
+    if current_owner.lower() != qs_master_safe.lower():
+        raise _Unmigratable(
+            service_id=sid, chain=chain_str,
+            reason=f"NFT owner is {current_owner}, expected quickstart "
+                   f"({qs_master_safe}) or Pearl ({pearl_master_safe}) Safe.",
+        )
+    ensure_signable()
+    info(f"  transferring service NFT {token_id} {qs_master_safe} -> {pearl_master_safe}")
+    try:
+        transfer_service_nft(
+            ledger_api=ledger_api, crypto=qs_wallet.crypto,
+            service_registry_address=registry_addr,
+            qs_master_safe=qs_master_safe,
+            pearl_master_safe=pearl_master_safe,
+            service_id=token_id,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        raise _wrap_step_failure(
+            sid=sid, chain=chain_str,
+            prefix="NFT transfer failed", exc=exc,
+        )
+
+
+def _step_swap_service_safe_owner(
+    *, ledger_api: Any, qs_wallet: Any, service_safe: str,
+    qs_master_safe: str, pearl_master_safe: str,
+    sid: str, chain_str: str,
+    ensure_signable,
+) -> None:
+    """Swap the service multisig's owner from qs Safe to Pearl Safe (idempotent)."""
+    from scripts.pearl_migration.transfer import swap_service_safe_owner
+
+    try:
+        owners = safe_owners(ledger_api=ledger_api, safe=service_safe)
+    except Exception as exc:  # pylint: disable=broad-except
+        raise _wrap_step_failure(
+            sid=sid, chain=chain_str,
+            prefix=f"could not read service Safe owners on {service_safe}",
+            exc=exc,
+        )
+    owners_lower = {o.lower() for o in owners}
+    pearl_present = pearl_master_safe.lower() in owners_lower
+    qs_present = qs_master_safe.lower() in owners_lower
+    if pearl_present and not qs_present:
+        info(f"    service Safe {service_safe} already swapped; skipping.")
+        return
+    if not qs_present:
+        raise _Unmigratable(
+            service_id=sid, chain=chain_str,
+            reason=f"service Safe {service_safe} owners are {owners}; "
+                   f"quickstart Safe ({qs_master_safe}) not found, can't swap.",
+        )
+    ensure_signable()
+    info(f"  swapping owner on service Safe {service_safe}")
+    try:
+        swap_service_safe_owner(
+            ledger_api=ledger_api, crypto=qs_wallet.crypto,
+            service_safe=service_safe,
+            old_owner=qs_master_safe, new_owner=pearl_master_safe,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        raise _wrap_step_failure(
+            sid=sid, chain=chain_str,
+            prefix=(
+                f"service Safe owner swap failed; NFT is now owned by Pearl "
+                f"Safe but service multisig {service_safe} still lists "
+                f"{qs_master_safe} as owner"
+            ),
+            exc=exc,
+        )
+
+
+def _migrate_one_service(
+    svc: Service,
+    qs_app: "OperateApp",
+    qs_wallet: "MasterWallet",
+    pearl_wallet: "MasterWallet",
+    config_path: Optional[str],
+) -> None:
+    """Stop, terminate, and on-chain transfer one service.
+
+    Per-chain orchestration: ensures Pearl has a master Safe on the chain,
+    builds the lazy ledger handle and threshold guard, then dispatches to
+    `_step_terminate` -> `_step_transfer_nft` -> `_step_swap_service_safe_owner`.
+    Each step is independently idempotent so re-runs after a partial failure
+    resume from the first incomplete step.
+
+    Filesystem copy is done by the caller after this returns successfully.
+    """
+    from operate.ledger.profiles import CONTRACTS
+
+    manager = qs_app.service_manager()
+    sid = svc.service_config_id
+    # Reload via the manager so we get a fully-validated Service tied to the
+    # live store (vs the snapshot returned by `OperateStore.services()`).
+    service = manager.load(service_config_id=sid)
+
+    # ---- stop deployment -----------------------------------------------------
+    if config_path:
+        try:
+            stop_via_middleware(operate=qs_app, config_path=config_path)
+        except Exception as exc:  # pylint: disable=broad-except
+            # Real programming bugs (e.g. middleware API drift) must NOT
+            # be demoted to a `warn(...)` and silently fall through to
+            # the on-chain branch.
+            _reraise_if_programming_bug(exc)
+            warn(f"stop_service via middleware failed: {exc}; trying force cleanup.")
+    # `force_remove_known_containers` raises `subprocess.TimeoutExpired` on
+    # docker daemon hang. `docker_quickstart_containers` raises
+    # `RuntimeError` if `docker ps` itself fails (permission denied on
+    # /var/run/docker.sock, daemon down, etc.). Convert both to a
+    # per-service `_Unmigratable` — proceeding to NFT transfer with
+    # containers possibly still signing with the agent key would race.
+    try:
+        force_remove_known_containers()
+    except (subprocess.TimeoutExpired, RuntimeError) as exc:
+        raise _Unmigratable(
+            service_id=sid, chain=None,
+            reason=f"could not confirm containers are stopped: {exc}. "
+                   "Stop the running deployment manually (`docker ps`, "
+                   "`docker rm -f`) and re-run.",
+        )
+    # Re-probe so a `force_remove_known_containers()` that returned
+    # cleanly but didn't actually remove the containers (e.g. docker
+    # daemon refused the rm with non-zero exit) still surfaces.
+    try:
+        remaining = docker_quickstart_containers()
+    except RuntimeError as exc:
+        raise _Unmigratable(
+            service_id=sid, chain=None,
+            reason=f"could not verify containers stopped: {exc}.",
+        )
+    if remaining:
+        raise _Unmigratable(
+            service_id=sid, chain=None,
+            reason=f"quickstart containers still running after cleanup: "
+                   f"{remaining}. Stop them manually before re-running.",
+        )
+
+    # ---- per-chain on-chain operations --------------------------------------
+    for chain_str, chain_config in service.chain_configs.items():
+        chain = Chain(chain_str)
+        chain_data = chain_config.chain_data
+        info(f"  chain {chain_str}: service NFT id = {chain_data.token}, multisig = {chain_data.multisig}")
+
+        # Both `qs_wallet.safes[chain]` and `CONTRACTS[chain][...]` raise
+        # KeyError on missing entries — legitimate per-service conditions
+        # (chain added to a service after the wallet was created, or a
+        # newer chain enum without a registered ServiceRegistry contract).
+        # `_PROGRAMMING_BUGS` deliberately excludes KeyError/LookupError
+        # so we MUST wrap here; otherwise a missing chain crashes the
+        # whole batch instead of becoming a per-service `_Unmigratable`.
+        try:
+            qs_master_safe = qs_wallet.safes[chain]
+        except KeyError:
+            raise _Unmigratable(
+                service_id=sid, chain=chain_str,
+                reason=f"quickstart master wallet has no Safe on {chain_str}; "
+                       "service references a chain the wallet was never "
+                       "configured for.",
+            )
+        try:
+            registry_addr = CONTRACTS[chain]["service_registry"]
+        except KeyError:
+            raise _Unmigratable(
+                service_id=sid, chain=chain_str,
+                reason=f"no ServiceRegistry contract registered for {chain_str} "
+                       "in middleware's CONTRACTS table; cannot read NFT owner "
+                       "or build the transfer.",
+            )
+        # Ensure Pearl has a master Safe on this chain. `create_safe` is
+        # the same factory that bootstraps Pearl on a new chain — required
+        # before the Safe owner swap can name a real `new_owner`.
+        if chain not in pearl_wallet.safes:
+            info(f"    Pearl has no master Safe on {chain_str}; creating one.")
+            try:
+                pearl_wallet.create_safe(
+                    chain=chain, rpc=chain_config.ledger_config.rpc,
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                _reraise_if_programming_bug(exc)
+                raise _Unmigratable(
+                    service_id=sid, chain=chain_str,
+                    reason=f"could not create Pearl master Safe on {chain_str}: {exc}.",
+                )
+        pearl_master_safe = pearl_wallet.safes[chain]
+
+        # `ledger_api` and the threshold guard are needed only inside the
+        # signing branches — defer so terminate-raise paths exercise without
+        # a fully populated wallet/ledger.
+        #
+        # `_cfg=chain_config` (default-arg binding) defends against a
+        # future refactor that defers iteration (e.g. collects callables
+        # to run later): without this binding, every deferred closure would
+        # read the LAST iteration's `chain_config`, signing chain N's tx
+        # against chain N+1's RPC. `nonlocal ledger_api` provides the
+        # within-iteration memoization (one ledger_api built per chain).
+        ledger_api: Optional[Any] = None
+
+        def _ledger_api(_cfg=chain_config) -> Any:
+            nonlocal ledger_api
+            if ledger_api is None:
+                ledger_api = manager.get_eth_safe_tx_builder(
+                    ledger_config=_cfg.ledger_config,
+                ).ledger_api
+            return ledger_api
+
+        def _ensure_signable() -> None:
+            """Raise `_Unmigratable` unless the qs master Safe is single-signer.
+
+            Called lazily, only inside branches that actually sign. Resumed
+            runs that find every step already done skip this entirely.
+            """
+            try:
+                t = safe_threshold(ledger_api=_ledger_api(), safe=qs_master_safe)
+            except Exception as exc:  # pylint: disable=broad-except
+                _reraise_if_programming_bug(exc)
+                raise _Unmigratable(
+                    service_id=sid, chain=chain_str,
+                    reason=f"could not read quickstart master Safe threshold on "
+                           f"{qs_master_safe}: {exc}.",
+                )
+            if t == 1:
+                return
+            if t == 0:
+                raise _Unmigratable(
+                    service_id=sid, chain=chain_str,
+                    reason=f"quickstart master Safe {qs_master_safe} reports "
+                           f"threshold 0 — appears unconfigured. Inspect on-chain "
+                           "state before retrying.",
+                )
+            raise _Unmigratable(
+                service_id=sid, chain=chain_str,
+                reason=f"quickstart master Safe {qs_master_safe} has threshold "
+                       f"{t}; this script signs single-owner only. Lower the "
+                       "threshold to 1 (temporarily) and re-run.",
+            )
+
+        _step_terminate(
+            manager=manager, service=service, sid=sid, chain_str=chain_str,
+            ensure_signable=_ensure_signable, on_chain_state_cls=OnChainState,
+        )
+        _step_transfer_nft(
+            ledger_api=_ledger_api(), qs_wallet=qs_wallet,
+            registry_addr=registry_addr,
+            qs_master_safe=qs_master_safe, pearl_master_safe=pearl_master_safe,
+            token_id=chain_data.token, sid=sid, chain_str=chain_str,
+            ensure_signable=_ensure_signable,
+        )
+        _step_swap_service_safe_owner(
+            ledger_api=_ledger_api(), qs_wallet=qs_wallet,
+            service_safe=chain_data.multisig,
+            qs_master_safe=qs_master_safe, pearl_master_safe=pearl_master_safe,
+            sid=sid, chain_str=chain_str,
+            ensure_signable=_ensure_signable,
+        )
+
+
+def _format_amount(amount: int, chain: "Chain", asset: str) -> str:
+    """Best-effort token formatter; falls back to raw wei when the asset
+    isn't in the middleware's `CHAIN_TO_METADATA` table.
+
+    Only catches the lookup failures (`KeyError` for unknown chain/asset);
+    everything else propagates so a bug in the formatter doesn't masquerade
+    as "raw wei output".
+    """
+    try:
+        return wei_to_token(amount, chain.value, asset)
+    except KeyError:
+        return f"{amount} of {asset}"
+
+
+def _drain_master(
+    qs_wallet: "MasterWallet", pearl_wallet: "MasterWallet",
+    chain_rpcs: Optional[Dict["Chain", str]] = None,
+) -> List[_DrainFailure]:
+    """Drain quickstart master Safe + EOA into Pearl per chain.
+
+    Returns a list of `_DrainFailure` entries — empty on full success.
+    Per-chain failures are accumulated rather than aborting; one chain's
+    RPC outage shouldn't prevent draining the others.
+
+    `chain_rpcs` (chain -> rpc URL) is used to spin up a Pearl master
+    Safe on chains where Pearl doesn't yet have one — so we can actually
+    drain into them instead of stranding the funds.
+    """
+    print_section("Draining quickstart master Safe + EOA into Pearl's.")
+    failures: List[_DrainFailure] = []
+    chain_rpcs = chain_rpcs or {}
+
+    for chain in qs_wallet.safes:
+        if chain not in pearl_wallet.safes:
+            # Pre-check: we need an RPC URL to create a Safe. If no
+            # migrated service used this chain, `chain_rpcs` won't have
+            # an entry, and passing `rpc=None` to `create_safe` would
+            # silently rely on whatever fallback the middleware does
+            # (often an unreliable public endpoint). Surface as a
+            # `_DrainFailure` immediately so the user knows funds on
+            # this chain weren't moved and why.
+            rpc = chain_rpcs.get(chain)
+            if rpc is None:
+                warn(
+                    f"  no RPC available for {chain.name}; skipping drain "
+                    "(quickstart had a Safe here but no migrated service "
+                    "exposed an RPC for this chain)."
+                )
+                failures.append(_DrainFailure(
+                    chain=chain,
+                    source_kind="Safe+EOA",
+                    source_address=qs_wallet.safes[chain],
+                    reason="no RPC available — quickstart had a Safe on "
+                           f"{chain.name} but no migrated service used "
+                           "this chain; cannot create Pearl Safe to "
+                           "drain into.",
+                ))
+                continue
+            info(f"  Pearl has no master Safe on {chain.name}; creating one.")
+            try:
+                pearl_wallet.create_safe(chain=chain, rpc=rpc)
+            except Exception as exc:  # pylint: disable=broad-except
+                _reraise_if_programming_bug(exc)
+                warn(f"  could not create Pearl Safe on {chain.name}: {exc}")
+                failures.append(_DrainFailure(
+                    chain=chain,
+                    source_kind="Safe+EOA",
+                    source_address=qs_wallet.safes[chain],
+                    reason=f"Pearl Safe creation failed: {exc}.",
+                ))
+                continue
+
+        # Master Safe -> Pearl master Safe (Pearl Safe receives ERC20s + native).
+        info(f"  [{chain.name}] master Safe -> Pearl master Safe ({pearl_wallet.safes[chain]})")
+        try:
+            moved = qs_wallet.drain(
+                withdrawal_address=pearl_wallet.safes[chain],
+                chain=chain,
+                from_safe=True,
+            )
+            if moved:
+                for asset, amount in moved.items():
+                    info(f"    moved {_format_amount(amount, chain, asset)}")
+            else:
+                # Distinguish "nothing to drain" from a silent middleware
+                # drop — explicit log line so the user can correlate with
+                # on-chain balance state if anything looks off later.
+                info(f"    no balances to move from Safe on {chain.name}")
+        except Exception as exc:  # pylint: disable=broad-except
+            _reraise_if_programming_bug(exc)
+            warn(f"  drain (Safe) on {chain.name} failed: {exc}")
+            failures.append(_DrainFailure(
+                chain=chain, source_kind="Safe",
+                source_address=qs_wallet.safes[chain], reason=str(exc),
+            ))
+
+        # Master EOA -> Pearl master EOA.
+        info(f"  [{chain.name}] master EOA -> Pearl master EOA ({pearl_wallet.address})")
+        try:
+            moved = qs_wallet.drain(
+                withdrawal_address=pearl_wallet.address,
+                chain=chain,
+                from_safe=False,
+            )
+            if moved:
+                for asset, amount in moved.items():
+                    info(f"    moved {_format_amount(amount, chain, asset)}")
+            else:
+                info(f"    no balances to move from EOA on {chain.name}")
+        except Exception as exc:  # pylint: disable=broad-except
+            _reraise_if_programming_bug(exc)
+            warn(f"  drain (EOA) on {chain.name} failed: {exc}")
+            failures.append(_DrainFailure(
+                chain=chain, source_kind="EOA",
+                source_address=qs_wallet.address, reason=str(exc),
+            ))
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Final user message
+# ---------------------------------------------------------------------------
+
+def _final_prompt(outcome: MigrationOutcome) -> None:
+    if not outcome.is_complete:
+        # Don't ask the "different machine?" question on a partial migration
+        # — the source `.operate/` is still authoritative; copying Pearl's
+        # half-state to another machine would just propagate the partial
+        # state. Print clear remediation guidance and return.
+        print_section("Migration incomplete — see warnings above.")
+        print()
+        print("  Some services or drains were left incomplete. The source")
+        print("  quickstart `.operate/` is preserved. Resolve the issues")
+        print("  flagged in the summary above and re-run `migrate_to_pearl.sh`.")
+        return
+    print_section("Migration complete.")
+    if yes_no(
+        "Do you want to run Pearl on a different machine than this one?",
+        default=False,
+    ):
+        print()
+        print("  Copy `~/.operate/` from this machine to `~/.operate` on the other")
+        print("  machine (same path). Pearl's bundled middleware will auto-migrate")
+        print("  any schema differences on first launch. Then start Pearl on that")
+        print("  machine and enter your master password.")
+    else:
+        print()
+        print("  Start Pearl now and enter your master password. Your migrated")
+        print("  services will appear in the dashboard.")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+    print_title("Quickstart -> Pearl migration")
+
+    try:
+        disc = discover(
+            quickstart_root=args.quickstart_home,
+            pearl_root=args.pearl_home,
+        )
+    except ValueError as exc:
+        # The discover() pipeline can raise ValueError from any of:
+        #   * `OperateStore.__post_init__` — unresolvable / inaccessible root,
+        #   * `Discovery.__post_init__` — same-root vs NOOP-mode mismatch,
+        #   * `discover()` itself — for any future invariants added inline.
+        # Surface as a clean fatal() rather than a raw stacktrace.
+        fatal(f"Discovery failed: {exc}")
+    _preflight(disc)
+
+    # Both branches return a `MigrationOutcome`. No `Optional` / `assert`
+    # — the type system enforces what was previously a runtime defence
+    # (which would have been stripped under `python -O`).
+    if disc.mode == Mode.FRESH_COPY:
+        outcome = _run_mode_a(disc=disc, dry_run=args.dry_run)
+    else:
+        services = _select_services(disc.quickstart, args.config_path)
+        outcome = _run_mode_b(
+            disc=disc,
+            services=services,
+            config_path=args.config_path,
+            dry_run=args.dry_run,
+        )
+
+    if not args.dry_run:
+        _final_prompt(outcome)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -686,7 +686,10 @@ def _step_transfer_nft(
     ensure_signable,
 ) -> None:
     """Transfer the service NFT to Pearl's master Safe (idempotent)."""
-    from scripts.pearl_migration.transfer import transfer_service_nft
+    from scripts.pearl_migration.transfer import (
+        PostConditionUnknown,
+        transfer_service_nft,
+    )
 
     current_owner = service_nft_owner(
         ledger_api=ledger_api,
@@ -718,6 +721,18 @@ def _step_transfer_nft(
             pearl_master_safe=pearl_master_safe,
             service_id=token_id,
         )
+    except PostConditionUnknown as exc:
+        # Distinct from "inner reverted": tx submitted, but the post-tx
+        # ownerOf read failed all retries. State is INDETERMINATE — DO NOT
+        # re-run blindly (a re-run after the NFT actually moved would hit
+        # `ERC721: caller not owner`). Surface unwrapped so the user sees
+        # the original guidance. `from exc` (PEP 3134) marks this as an
+        # intentional translation so the underlying RPC failure stays
+        # visible in the traceback chain.
+        raise _Unmigratable(
+            service_id=sid, chain=chain_str,
+            reason=str(exc),
+        ) from exc
     except Exception as exc:  # pylint: disable=broad-except
         raise _wrap_step_failure(
             sid=sid, chain=chain_str,
@@ -732,7 +747,10 @@ def _step_swap_service_safe_owner(
     ensure_signable,
 ) -> None:
     """Swap the service multisig's owner from qs Safe to Pearl Safe (idempotent)."""
-    from scripts.pearl_migration.transfer import swap_service_safe_owner
+    from scripts.pearl_migration.transfer import (
+        PostConditionUnknown,
+        swap_service_safe_owner,
+    )
 
     try:
         owners = safe_owners(ledger_api=ledger_api, safe=service_safe)
@@ -762,6 +780,19 @@ def _step_swap_service_safe_owner(
             service_safe=service_safe,
             old_owner=qs_master_safe, new_owner=pearl_master_safe,
         )
+    except PostConditionUnknown as exc:
+        # State is INDETERMINATE — execTransaction submitted but the
+        # post-tx getOwners read failed all retries. The NFT is already
+        # owned by Pearl, so a re-run that hits a post-condition mismatch
+        # (because the swap actually landed) is the WORST outcome:
+        # rename_source_for_rollback would erase qs/.operate believing
+        # success. Surface unwrapped so the user gets the explicit
+        # "verify on a block explorer first" guidance. `from exc`
+        # preserves the underlying RPC failure in the traceback chain.
+        raise _Unmigratable(
+            service_id=sid, chain=chain_str,
+            reason=str(exc),
+        ) from exc
     except Exception as exc:  # pylint: disable=broad-except
         raise _wrap_step_failure(
             sid=sid, chain=chain_str,

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -100,11 +100,43 @@ def _wrap_step_failure(
     Everything else — including `KeyError`/`LookupError` raised by web3
     or middleware on missing chain metadata — gets wrapped so a single
     bad chain doesn't crash the whole multi-service batch.
+
+    Walks the `__cause__`/`__context__` chain and appends the deepest
+    non-trivial exception. Middleware wraps low-level errors in generic
+    `click.ClickException` (e.g. `OnChainHelper.load_crypto` raises
+    "Cannot load private key" while the actual `KeyIsIncorrect` /
+    `DecryptError` carries the file path and underlying reason). Without
+    chaining, the `_Unmigratable.reason` shows only the generic message
+    and the user has no way to tell wrong-password from malformed file
+    from missing path.
     """
     _reraise_if_programming_bug(exc)
     return _Unmigratable(
-        service_id=sid, chain=chain, reason=f"{prefix}: {exc}.",
+        service_id=sid, chain=chain,
+        reason=f"{prefix}: {_format_exc_chain(exc)}.",
     )
+
+
+def _format_exc_chain(exc: BaseException) -> str:
+    """Render `exc` plus the deepest distinct chained cause.
+
+    `__cause__` (explicit `raise X from Y`) wins over `__context__`
+    (implicit "during handling of"), since the explicit chain is what
+    library authors use to surface the underlying reason. We stop at the
+    first non-trivial cause whose string differs from the outer
+    exception's — adding "(caused by: 'foo')" when both stringify to
+    "foo" is noise.
+    """
+    seen: set[int] = set()
+    outer_str = str(exc)
+    cur: Optional[BaseException] = exc.__cause__ or exc.__context__
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        cur_str = str(cur)
+        if cur_str and cur_str != outer_str:
+            return f"{outer_str} (caused by {type(cur).__name__}: {cur_str})"
+        cur = cur.__cause__ or cur.__context__
+    return outer_str
 
 
 # Poll cadence for `_wait_for_native_funds`. Five seconds matches the

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -73,6 +73,7 @@ _PROGRAMMING_BUGS: Tuple[Type[BaseException], ...] = (
     AttributeError,
     NameError,
     ImportError,
+    AssertionError,
 )
 
 
@@ -325,7 +326,10 @@ from scripts.pearl_migration.stop import (
     force_remove_known_containers,
     stop_via_middleware,
 )
-from scripts.pearl_migration.wallet import align_quickstart_password
+from scripts.pearl_migration.wallet import (
+    align_quickstart_password,
+    align_user_account_to_wallet,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -486,6 +490,9 @@ def _load_wallet(
     # Password good; now safe to build the full app (with migrations).
     app = store.operate_app(password=pw)
     wallet = app.wallet_manager.load(LedgerType.ETHEREUM)
+    # Align `user.json` to the wallet password at the source — see
+    # `align_user_account_to_wallet` for why.
+    align_user_account_to_wallet(app)
     return app, wallet
 
 
@@ -726,11 +733,19 @@ def _run_mode_b(
         )
         if not yes_no("Proceed with re-encryption?", default=True):
             fatal("Migration aborted by user; nothing on-chain has changed.")
-        align_quickstart_password(
-            qs_app=qs_app,
-            qs_wallet=qs_wallet,
-            new_password=pearl_app.password,
-        )
+        try:
+            align_quickstart_password(
+                qs_app=qs_app,
+                qs_wallet=qs_wallet,
+                new_password=pearl_app.password,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            _reraise_if_programming_bug(exc)
+            fatal(
+                f"password alignment failed: {exc}. See the warning above "
+                "for the specific recovery steps; nothing on-chain has "
+                "changed yet."
+            )
 
     fix_root_ownership(disc.quickstart)
 

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -49,7 +49,7 @@ from typing import (
     Type,
 )
 
-from operate.constants import ZERO_ADDRESS
+from operate.constants import NO_STAKING_PROGRAM_ID, ZERO_ADDRESS
 from operate.operate_types import Chain, OnChainState
 from operate.quickstart.utils import (
     print_section,
@@ -307,6 +307,7 @@ from scripts.pearl_migration.filesystem import (
     fresh_copy_store,
     merge_service,
     rename_source_for_rollback,
+    reset_services_staking_to_no_staking,
 )
 from scripts.pearl_migration.prompts import (
     ask_password_validating,
@@ -591,6 +592,18 @@ def _run_mode_a(disc: Discovery, dry_run: bool) -> MigrationOutcome:
     fix_root_ownership(disc.quickstart)
 
     fresh_copy_store(disc.quickstart, disc.pearl.root)
+    # Match Mode B: pin every migrated service's `staking_program_id` to
+    # `no_staking` so Pearl doesn't try to re-apply quickstart's staking
+    # template. Done on the destination so the source `.operate/` we're
+    # about to rename stays an untouched rollback. Re-running is a no-op.
+    updated = reset_services_staking_to_no_staking(
+        OperateStore(root=disc.pearl.root),
+    )
+    if updated:
+        info(
+            f"Reset staking_program_id to no_staking for {len(updated)} "
+            f"service(s): {', '.join(updated)}.",
+        )
     print()
     info("Renaming source `.operate/` so a re-run won't pick it up.")
     rename_source_for_rollback(disc.quickstart)
@@ -1244,6 +1257,30 @@ def _migrate_one_service(
             qs_master_safe=qs_master_safe, pearl_master_safe=pearl_master_safe,
             sid=sid, chain_str=chain_str,
             ensure_signable=_ensure_signable,
+        )
+
+    # All chains migrated. Pin the service's local config to `no_staking`
+    # so Pearl sees the post-migration on-chain reality (PRE_REGISTRATION,
+    # NFT owned by Pearl Safe). It's required because Pearl's FE expects it
+    # to continue the onbarding of this agent.
+    for chain_config in service.chain_configs.values():
+        chain_config.chain_data.user_params.staking_program_id = (
+            NO_STAKING_PROGRAM_ID
+        )
+    try:
+        service.store()
+    except OSError as exc:
+        # On-chain ops have committed; a `_Unmigratable` here skips the
+        # filesystem copy (`merge_service`) and surfaces in the summary
+        # so the user can re-run after fixing the disk/permission issue.
+        raise _Unmigratable(
+            service_id=sid, chain=None,
+            reason=(
+                "on-chain migration committed but local "
+                f"`staking_program_id` write failed: {exc}. Re-run after "
+                "resolving the disk/permission issue; the on-chain steps "
+                "are idempotent."
+            ),
         )
 
 

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -1445,12 +1445,12 @@ def _final_prompt(outcome: MigrationOutcome) -> None:
         print()
         print("  Copy `~/.operate/` from this machine to `~/.operate` on the other")
         print("  machine (same path). Pearl's bundled middleware will auto-migrate")
-        print("  any schema differences on first launch. Then start Pearl on that")
-        print("  machine and enter your master password.")
+        print("  any schema differences on first launch. Then start the latest version")
+        print("  of Pearl on that machine and enter your master password.")
     else:
         print()
-        print("  Start Pearl now and enter your master password. Your migrated")
-        print("  services will appear in the dashboard.")
+        print("  Start the latest version of Pearl now and enter your master password.")
+        print("  Your migrated services will appear in the dashboard.")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/pearl_migration/migrate_to_pearl.py
+++ b/scripts/pearl_migration/migrate_to_pearl.py
@@ -688,10 +688,21 @@ class MigrationOutcome:
     migrated: Tuple[Service, ...] = ()
     unmigratable: Tuple["_Unmigratable", ...] = ()
     drain_failures: Tuple[_DrainFailure, ...] = ()
+    # True when the user migrated only a subset of the quickstart's
+    # services (e.g. via `--quickstart-config <path>` or by picking a
+    # single entry from the multi-service prompt). The master Safe / EOA
+    # drain is skipped in that case so the unselected services still
+    # have funds for gas, and the source `.operate/` is left in place
+    # so a later run can pick the rest up.
+    subset_selected: bool = False
 
     @property
     def is_complete(self) -> bool:
-        return not self.unmigratable and not self.drain_failures
+        return (
+            not self.unmigratable
+            and not self.drain_failures
+            and not self.subset_selected
+        )
 
     @property
     def migrated_count(self) -> int:
@@ -703,15 +714,26 @@ def _run_mode_b(
     services: List[Service],
     config_path: Optional[str],
     dry_run: bool,
+    subset_selected: bool = False,
 ) -> MigrationOutcome:
     """Returns the structured `MigrationOutcome`. `outcome.is_complete` False
-    suppresses the source-`.operate/` rename so the user can resume."""
+    suppresses the source-`.operate/` rename so the user can resume.
+
+    `subset_selected` is the caller's signal that `services` is only some
+    of what the quickstart store currently exposes (the user picked via
+    `--quickstart-config` or by selecting a single entry from the
+    multi-service prompt). When True, the master-wallet drain is skipped
+    so the unselected services keep their shared gas funds, and the
+    source `.operate/` is left in place so a later run can pick the rest
+    up. Defaults to False — the dominant production path and what
+    existing single-service test fixtures rely on.
+    """
     print_section("MERGE")
     info(f"Will migrate {len(services)} service(s): " + ", ".join(s.name for s in services))
 
     if dry_run:
         info("[dry-run] Stopping at discovery; no on-chain or filesystem actions taken.")
-        return MigrationOutcome()
+        return MigrationOutcome(subset_selected=subset_selected)
 
     # If `OperateStore.services()` dropped any malformed configs we MUST NOT
     # drain — the dropped service's NFT/Safe would be orphaned with empty
@@ -838,6 +860,13 @@ def _run_mode_b(
             "Skipping the master-Safe and master-EOA drains so funds remain "
             "available for completing those migrations later.",
         )
+    elif subset_selected:
+        print()
+        warn(
+            "Only a subset of the quickstart's services was migrated. "
+            "Skipping the master-Safe and master-EOA drains so the "
+            "remaining quickstart services keep their gas funds.",
+        )
     else:
         drain_failures = _drain_master(
             qs_wallet=qs_wallet, pearl_wallet=pearl_wallet,
@@ -848,6 +877,7 @@ def _run_mode_b(
         migrated=tuple(migrated),
         unmigratable=tuple(unmigratable),
         drain_failures=tuple(drain_failures),
+        subset_selected=subset_selected,
     )
 
     # ---- final summary -------------------------------------------------------
@@ -855,7 +885,9 @@ def _run_mode_b(
 
     # ---- rename source -------------------------------------------------------
     # Never rename when the migration is incomplete: the user needs the
-    # source `.operate/` discoverable to resume.
+    # source `.operate/` discoverable to resume — whether "incomplete"
+    # means failures (`unmigratable` / `drain_failures`) or a deliberate
+    # subset selection (the unselected services still live in the source).
     if migrated and outcome.is_complete:
         print()
         if yes_no(
@@ -864,10 +896,14 @@ def _run_mode_b(
         ):
             rename_source_for_rollback(disc.quickstart)
     elif not outcome.is_complete:
+        if outcome.subset_selected and not outcome.unmigratable and not outcome.drain_failures:
+            reason = "remaining services still live in the source"
+        else:
+            reason = "migration incomplete"
         info(
-            "Source `.operate/` left in place (migration incomplete) — "
+            f"Source `.operate/` left in place ({reason}) — "
             f"re-run `migrate_to_pearl.sh` from {disc.quickstart.root.parent} "
-            "after addressing the issues above.",
+            "when ready to continue.",
         )
 
     return outcome
@@ -898,6 +934,17 @@ def _print_migration_summary(outcome: MigrationOutcome) -> None:
             "  Funds may still be present on the quickstart wallet on these "
             "chains. Re-run after resolving the underlying issue (RPC, gas, "
             "etc.) to retry the drain.",
+        )
+    if outcome.subset_selected and not outcome.unmigratable:
+        # Only surface the subset note when there's no unmigratable list
+        # competing for the user's attention — unmigratable failures imply
+        # their own re-run, and stacking another "re-run for the rest"
+        # message on top would muddle the next action.
+        info(
+            "  subset migration: master-Safe and master-EOA drains were "
+            "skipped because not every quickstart service was selected. "
+            "Re-run later to migrate the remaining services and "
+            "drain the shared master wallet.",
         )
 
 
@@ -1431,6 +1478,18 @@ def _final_prompt(outcome: MigrationOutcome) -> None:
         # — the source `.operate/` is still authoritative; copying Pearl's
         # half-state to another machine would just propagate the partial
         # state. Print clear remediation guidance and return.
+        if (
+            outcome.subset_selected
+            and not outcome.unmigratable
+            and not outcome.drain_failures
+        ):
+            print_section("Selected services migrated; remaining services left in source.")
+            print()
+            print("  The migrated services will appear in Pearl. The source")
+            print("  quickstart `.operate/` is preserved with the unselected")
+            print("  services intact — re-run `migrate_to_pearl.sh` when")
+            print("  you're ready to migrate the rest and drain the master wallet.")
+            return
         print_section("Migration incomplete — see warnings above.")
         print()
         print("  Some services or drains were left incomplete. The source")
@@ -1482,11 +1541,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         outcome = _run_mode_a(disc=disc, dry_run=args.dry_run)
     else:
         services = _select_services(disc.quickstart, args.config_path)
+        # Compare ids (not Service objects) because `OperateStore.services()`
+        # returns freshly-loaded instances on every call, so identity
+        # comparison would always be False. The lookup is cheap (a sorted
+        # `iterdir` + per-dir `Service.load`) and only runs once at startup.
+        selected_ids = {s.service_config_id for s in services}
+        available_ids = {s.service_config_id for s in disc.quickstart.services()}
         outcome = _run_mode_b(
             disc=disc,
             services=services,
             config_path=args.config_path,
             dry_run=args.dry_run,
+            subset_selected=selected_ids != available_ids,
         )
 
     if not args.dry_run:

--- a/scripts/pearl_migration/prompts.py
+++ b/scripts/pearl_migration/prompts.py
@@ -1,0 +1,160 @@
+"""Interactive prompts.
+
+Thin wrappers over `operate.quickstart.utils` so we share the same UX with
+the existing migration script (`scripts/predict_trader/migrate_legacy_quickstart.py`)
+and inherit middleware features for free:
+
+- `ATTENDED=false` env var → `ask_yes_or_no` returns True automatically (CI mode).
+- `OPERATE_PASSWORD` env var → `ask_or_get_from_env(..., is_pass=True)` short-circuits.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional
+
+from operate.quickstart.utils import ask_or_get_from_env, ask_yes_or_no
+
+
+class CollisionChoice(Enum):
+    SKIP = "skip"
+    OVERWRITE_WITH_BACKUP = "overwrite"
+
+
+def yes_no(question: str, default: Optional[bool] = None) -> bool:
+    """Yes/no prompt.
+
+    * Attended mode (default): prompts via middleware's `ask_yes_or_no`,
+      which loops until the user types yes/no (no empty-input shortcut).
+      If `default` is supplied we still pass it through to a one-line
+      empty-input fallback so code that wants the legacy "[Y/n]" feel
+      keeps working.
+    * Unattended mode (`ATTENDED=false`): the middleware unconditionally
+      returns True. We bypass it when `default` is supplied so each prompt
+      gets its declared safe default (e.g. the rename-source prompt
+      defaulting to True is fine; "different machine?" defaulting to False
+      is what we want — middleware would say True here).
+    """
+    if not _attended():
+        return True if default is None else default
+    if default is None:
+        return ask_yes_or_no(question)
+    suffix = " [Y/n] " if default else " [y/N] "
+    while True:
+        try:
+            raw = input(question + suffix).strip().lower()
+        except EOFError:
+            # Closed/piped stdin — fall back to the declared default
+            # rather than crashing. The end-of-migration prompts
+            # (rename-source, "different machine?") both pass an
+            # explicit default, so this is meaningful.
+            return default
+        if not raw:
+            return default
+        if raw in ("y", "yes"):
+            return True
+        if raw in ("n", "no"):
+            return False
+
+
+def _attended() -> bool:
+    import os
+    return os.environ.get("ATTENDED", "true").lower() == "true"
+
+
+def password(
+    prompt: str = "Password: ", env_var_name: str = "OPERATE_PASSWORD",
+) -> str:
+    """Password prompt, defers to middleware's `ask_or_get_from_env`.
+
+    Reads `OPERATE_PASSWORD` (or the supplied `env_var_name`) when set or
+    when `ATTENDED=false`. Otherwise falls back to interactive `getpass`.
+    """
+    return ask_or_get_from_env(
+        prompt=prompt,
+        is_pass=True,
+        env_var_name=env_var_name,
+        raise_if_missing=False,
+    )
+
+
+def collision(target: Path, kind: str) -> CollisionChoice:
+    """Ask the user how to resolve a destination collision.
+
+    `kind` is "service" or "key" — used only for the message.
+    Tells the user this most likely means a previous migration was retried.
+
+    Called from `merge_service` AFTER on-chain ops have committed, so a
+    raw `EOFError` traceback here (closed/piped stdin in CI) would abort
+    the for-loop, skip drain + rename, and leave the user with no
+    summary. We default to SKIP (the safe choice — assumes the existing
+    dest is the intended migrated copy) and warn so it's visible.
+    """
+    print()
+    print(f"  ! {kind.capitalize()} already exists at destination: {target}")
+    print(
+        "    This usually means you're re-running a migration that previously "
+        "got partway. Pick how to handle it:"
+    )
+    print("      1) Skip — leave the destination untouched (safe if it's the migrated copy).")
+    print("      2) Overwrite with backup — rename existing to .bak.<ts> then copy fresh.")
+    while True:
+        try:
+            raw = input("    Choice [1/2]: ").strip()
+        except EOFError:
+            warn(
+                f"stdin closed while resolving collision for {target}; "
+                "defaulting to SKIP (existing destination preserved)."
+            )
+            return CollisionChoice.SKIP
+        if raw == "1":
+            return CollisionChoice.SKIP
+        if raw == "2":
+            return CollisionChoice.OVERWRITE_WITH_BACKUP
+        warn(f"Invalid choice {raw!r}; enter 1 or 2.")
+
+
+def backup_suffix() -> str:
+    """Timestamp suffix used for `.bak.<ts>` paths."""
+    return f"bak.{int(time.time())}"
+
+
+def info(msg: str) -> None:
+    print(f"  - {msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"  ! {msg}")
+
+
+def fatal(msg: str, code: int = 1) -> None:
+    print(f"  X {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def ask_password_validating(
+    prompt: str,
+    validate: Callable[[str], bool],
+    *,
+    attempts: int = 3,
+    not_match_msg: str = "Wrong password.",
+) -> Optional[str]:
+    """Prompt for a password up to `attempts` times, calling `validate(pw) -> bool`.
+
+    Returns the password on success, None if the user gave up. Validation
+    exceptions are surfaced (so RPC failures abort cleanly rather than masquerade
+    as a wrong password).
+    """
+    for i in range(attempts):
+        pw = password(prompt)
+        if validate(pw):
+            return pw
+        remaining = attempts - i - 1
+        if remaining:
+            warn(f"{not_match_msg} {remaining} attempt(s) left.")
+        else:
+            warn(not_match_msg)
+    return None

--- a/scripts/pearl_migration/status.py
+++ b/scripts/pearl_migration/status.py
@@ -1,0 +1,145 @@
+"""Source-of-truth queries.
+
+Every step in the migration calls into here to ask the network / OS / disk
+"is X already done?". We keep these reads side-effect-free so the orchestrator
+can use them as both pre-flight checks and idempotency probes after a crash.
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from aea.crypto.base import LedgerApi
+
+
+PEARL_DAEMON_PORT = 8765
+QUICKSTART_CONTAINER_NAMES = ("abci0", "node0", "_abci_0", "_tm_0")
+
+
+def pearl_daemon_running(host: str = "127.0.0.1", port: int = PEARL_DAEMON_PORT) -> bool:
+    """TCP probe: True if anything is listening on Pearl's daemon port.
+
+    Only treats "connection refused" / "timeout" as "not running". Any
+    other socket error (file-descriptor exhaustion, network unreachable,
+    permission denied) propagates so the caller doesn't silently proceed
+    against a Pearl that's actually up but momentarily unreachable.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        try:
+            sock.connect((host, port))
+            return True
+        except (ConnectionRefusedError, socket.timeout):
+            return False
+
+
+def docker_quickstart_containers() -> List[str]:
+    """Return any quickstart-managed containers currently present.
+
+    Distinguishes "docker isn't installed" (return []) from "docker daemon
+    is hung" (raise). Silently swallowing the latter would let the caller
+    proceed believing there are no containers when there actually are.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "-a", "--format", "{{.Names}}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return []   # docker not installed at all — caller can proceed.
+    # subprocess.TimeoutExpired and any other error propagates.
+    if result.returncode != 0:
+        # Non-zero with docker installed = daemon refusing to talk
+        # (permission denied on /var/run/docker.sock, daemon crash,
+        # etc.). Returning [] would let callers conclude "no containers"
+        # and race a still-running deployment. Raise so the orchestrator
+        # surfaces a clear error instead.
+        stderr = (result.stderr or "").strip() or "(no stderr)"
+        raise RuntimeError(
+            f"`docker ps` exited {result.returncode}: {stderr}. "
+            "Cannot tell whether quickstart containers are still running."
+        )
+    names = set(result.stdout.split())
+    return sorted(n for n in QUICKSTART_CONTAINER_NAMES if n in names)
+
+
+def is_root_owned(path: Path) -> bool:
+    """True if `path` exists and is owned by uid 0.
+
+    `OSError` from `path.stat()` (permission denied, broken symlink) is
+    propagated rather than treated as "not root-owned" — silently
+    returning `False` would let `fix_root_ownership` skip the chown
+    and the subsequent `shutil.copytree` would corrupt the destination.
+    """
+    if not path.exists():
+        return False
+    return path.stat().st_uid == 0
+
+
+def any_root_owned_under(path: Path) -> bool:
+    """Recursively check if any file/dir under `path` is root-owned.
+
+    Permission errors (`OSError`) are NOT swallowed: a permission
+    denied while walking the tree means we can't tell whether a
+    root-owned file is hiding beneath, so we MUST propagate so the
+    caller (`fix_root_ownership`) refuses to proceed instead of
+    silently skipping the chown and corrupting the destination copy.
+    """
+    if not path.exists():
+        return False
+    if is_root_owned(path):
+        return True
+    for child in path.rglob("*"):
+        if child.stat().st_uid == 0:
+            return True
+    return False
+
+
+def service_nft_owner(
+    ledger_api: "LedgerApi",
+    service_registry_address: str,
+    service_id: int,
+) -> Optional[str]:
+    """ServiceRegistry.ownerOf(service_id). Returns checksum address or None on revert.
+
+    Only catches `web3.exceptions.ContractLogicError` (the contract revert
+    we expect for non-existent / burnt tokens). Network/RPC errors and any
+    other unexpected exception propagate so the caller can distinguish
+    "token doesn't exist" from "we can't tell right now".
+    """
+    from autonomy.chain.base import registry_contracts
+    from web3.exceptions import ContractLogicError
+
+    instance = registry_contracts.service_registry.get_instance(
+        ledger_api=ledger_api,
+        contract_address=service_registry_address,
+    )
+    try:
+        return instance.functions.ownerOf(service_id).call()
+    except ContractLogicError:
+        return None
+
+
+def safe_owners(ledger_api: "LedgerApi", safe: str) -> List[str]:
+    """Return the current owner list of a Gnosis Safe."""
+    from operate.utils.gnosis import get_owners
+
+    return list(get_owners(ledger_api=ledger_api, safe=safe))
+
+
+def safe_threshold(ledger_api: "LedgerApi", safe: str) -> int:
+    """Return the current signature threshold of a Gnosis Safe."""
+    from autonomy.chain.base import registry_contracts
+
+    instance = registry_contracts.gnosis_safe.get_instance(
+        ledger_api=ledger_api,
+        contract_address=safe,
+    )
+    return int(instance.functions.getThreshold().call())

--- a/scripts/pearl_migration/status.py
+++ b/scripts/pearl_migration/status.py
@@ -17,7 +17,14 @@ if TYPE_CHECKING:
 
 
 PEARL_DAEMON_PORT = 8765
-QUICKSTART_CONTAINER_NAMES = ("abci0", "node0", "_abci_0", "_tm_0")
+# Substring fragments used to detect quickstart-managed containers. The
+# middleware names ABCI / Tendermint containers as `<service>_abci_<idx>`
+# and `<service>_tm_<idx>` (see `autonomy/deploy/base.py:get_abci_container_name`),
+# so the fragments `_abci_0` and `_tm_0` catch the per-service variants
+# (`trader_abci_0`, `meme_factory_tm_0`, ...). `abci0` / `node0` are the
+# old monolithic names from pre-`<service>_` deployments — kept so legacy
+# installs are still detected.
+QUICKSTART_CONTAINER_FRAGMENTS = ("abci0", "node0", "_abci_0", "_tm_0")
 
 
 def pearl_daemon_running(host: str = "127.0.0.1", port: int = PEARL_DAEMON_PORT) -> bool:
@@ -66,8 +73,15 @@ def docker_quickstart_containers() -> List[str]:
             f"`docker ps` exited {result.returncode}: {stderr}. "
             "Cannot tell whether quickstart containers are still running."
         )
-    names = set(result.stdout.split())
-    return sorted(n for n in QUICKSTART_CONTAINER_NAMES if n in names)
+    # Substring match — `_abci_0` / `_tm_0` are fragments, not exact names
+    # (see comment on `QUICKSTART_CONTAINER_FRAGMENTS`). Exact-set matching
+    # would silently skip per-service containers like `trader_abci_0` and
+    # let the migration race a still-running deployment.
+    names = result.stdout.split()
+    return sorted(
+        name for name in names
+        if any(frag in name for frag in QUICKSTART_CONTAINER_FRAGMENTS)
+    )
 
 
 def is_root_owned(path: Path) -> bool:

--- a/scripts/pearl_migration/stop.py
+++ b/scripts/pearl_migration/stop.py
@@ -32,12 +32,15 @@ def force_remove_known_containers() -> List[str]:
 
     Returns the list of container names that were forcibly removed.
 
-    Raises `subprocess.TimeoutExpired` on `docker rm -f` hang — silently
-    returning `[]` would be indistinguishable from "nothing to remove",
-    letting on-chain steps proceed against a still-running deployment
-    that may sign txs with the agent key. Only `FileNotFoundError`
-    (docker not installed) is swallowed, in which case the upstream
-    `docker_quickstart_containers()` would already have returned `[]`.
+    Raises `subprocess.TimeoutExpired` on `docker rm -f` hang and
+    `RuntimeError` on a non-zero `docker rm -f` exit (daemon refused the
+    rm, permission denied on `/var/run/docker.sock`, container in a
+    transitional state, etc.) — silently returning `[]` would be
+    indistinguishable from "nothing to remove", letting on-chain steps
+    proceed against a still-running deployment that may sign txs with
+    the agent key. Only `FileNotFoundError` (docker not installed) is
+    swallowed, in which case the upstream `docker_quickstart_containers()`
+    would already have returned `[]`.
     """
     leftovers = docker_quickstart_containers()
     if not leftovers:
@@ -45,12 +48,17 @@ def force_remove_known_containers() -> List[str]:
     try:
         subprocess.run(
             ["docker", "rm", "-f", *leftovers],
-            check=False,
+            check=True,
             capture_output=True,
             timeout=30,
         )
     except FileNotFoundError:
         return []
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or b"").decode("utf-8", errors="replace").strip()
+        raise RuntimeError(
+            f"`docker rm -f` exited {exc.returncode}: {stderr or '(no stderr)'}"
+        ) from exc
     return leftovers
 
 

--- a/scripts/pearl_migration/stop.py
+++ b/scripts/pearl_migration/stop.py
@@ -1,0 +1,61 @@
+"""Stop the running quickstart deployment cleanly."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, List
+
+from .status import QUICKSTART_CONTAINER_NAMES, docker_quickstart_containers
+
+if TYPE_CHECKING:
+    from operate.cli import OperateApp
+
+
+def stop_via_middleware(operate: "OperateApp", config_path: str) -> None:
+    """Defer to the middleware's quickstart `stop_service` flow.
+
+    This composes down the docker stack the way `./stop_service.sh` does,
+    so middleware bookkeeping (DeploymentStatus etc.) is updated correctly.
+    """
+    from operate.quickstart.stop_service import stop_service
+
+    stop_service(operate=operate, config_path=config_path)
+
+
+def force_remove_known_containers() -> List[str]:
+    """Best-effort cleanup of any quickstart containers still around.
+
+    Mirrors the `docker rm -f` block at the top of `run_service.sh`
+    (matching the suffix patterns in `QUICKSTART_CONTAINER_NAMES`) so a
+    half-stopped deployment can't conflict with Pearl picking the
+    migrated services up.
+
+    Returns the list of container names that were forcibly removed.
+
+    Raises `subprocess.TimeoutExpired` on `docker rm -f` hang — silently
+    returning `[]` would be indistinguishable from "nothing to remove",
+    letting on-chain steps proceed against a still-running deployment
+    that may sign txs with the agent key. Only `FileNotFoundError`
+    (docker not installed) is swallowed, in which case the upstream
+    `docker_quickstart_containers()` would already have returned `[]`.
+    """
+    leftovers = docker_quickstart_containers()
+    if not leftovers:
+        return []
+    try:
+        subprocess.run(
+            ["docker", "rm", "-f", *leftovers],
+            check=False,
+            capture_output=True,
+            timeout=30,
+        )
+    except FileNotFoundError:
+        return []
+    return leftovers
+
+
+__all__ = [
+    "QUICKSTART_CONTAINER_NAMES",
+    "force_remove_known_containers",
+    "stop_via_middleware",
+]

--- a/scripts/pearl_migration/stop.py
+++ b/scripts/pearl_migration/stop.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from typing import TYPE_CHECKING, List
 
-from .status import QUICKSTART_CONTAINER_NAMES, docker_quickstart_containers
+from .status import QUICKSTART_CONTAINER_FRAGMENTS, docker_quickstart_containers
 
 if TYPE_CHECKING:
     from operate.cli import OperateApp
@@ -50,8 +50,8 @@ def force_remove_known_containers() -> List[str]:
     """Best-effort cleanup of any quickstart containers still around.
 
     Mirrors the `docker rm -f` block at the top of `run_service.sh`
-    (matching the suffix patterns in `QUICKSTART_CONTAINER_NAMES`) so a
-    half-stopped deployment can't conflict with Pearl picking the
+    (matching the substring fragments in `QUICKSTART_CONTAINER_FRAGMENTS`)
+    so a half-stopped deployment can't conflict with Pearl picking the
     migrated services up.
 
     Returns the list of container names that were forcibly removed.
@@ -87,7 +87,7 @@ def force_remove_known_containers() -> List[str]:
 
 
 __all__ = [
-    "QUICKSTART_CONTAINER_NAMES",
+    "QUICKSTART_CONTAINER_FRAGMENTS",
     "force_remove_known_containers",
     "stop_via_middleware",
 ]

--- a/scripts/pearl_migration/stop.py
+++ b/scripts/pearl_migration/stop.py
@@ -14,12 +14,36 @@ if TYPE_CHECKING:
 def stop_via_middleware(operate: "OperateApp", config_path: str) -> None:
     """Defer to the middleware's quickstart `stop_service` flow.
 
-    This composes down the docker stack the way `./stop_service.sh` does,
-    so middleware bookkeeping (DeploymentStatus etc.) is updated correctly.
+    Composes down the docker stack the way `./stop_service.sh` does,
+    so middleware bookkeeping (DeploymentStatus etc.) is updated.
+
+    Middleware's `stop_service` calls `ask_password_if_needed`, which
+    interactively re-prompts for a password we've already validated.
+    Set `OPERATE_PASSWORD` plus `ATTENDED=false` for the duration of
+    the call so middleware reads the password from the env (only when
+    BOTH are set; otherwise `ask_or_get_from_env` raises) and skips
+    the redundant prompt. Restore the env afterwards so unattended
+    mode doesn't leak into post-stop steps. Callers must ensure
+    `user.json`'s hash already matches `operate.password` — see
+    `align_user_account_to_wallet` for the full divergence background;
+    a diverged hash would loop forever in unattended mode.
     """
+    import os
+
     from operate.quickstart.stop_service import stop_service
 
-    stop_service(operate=operate, config_path=config_path)
+    saved_env = {k: os.environ.get(k) for k in ("OPERATE_PASSWORD", "ATTENDED")}
+    if operate.password is not None:
+        os.environ["OPERATE_PASSWORD"] = operate.password
+        os.environ["ATTENDED"] = "false"
+    try:
+        stop_service(operate=operate, config_path=config_path)
+    finally:
+        for k, v in saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 def force_remove_known_containers() -> List[str]:

--- a/scripts/pearl_migration/transfer.py
+++ b/scripts/pearl_migration/transfer.py
@@ -17,16 +17,151 @@ Two operations are needed in Mode B per service per chain:
    Safes we control end-to-end, so the receiver hook adds no real safety.
 
 2. **Service-Safe owner swap** — replace the quickstart master Safe with the
-   Pearl master Safe in the service multisig's owner list. Reuses
-   `operate.utils.gnosis.swap_owner` directly.
+   Pearl master Safe in the service multisig's owner list. Cannot use
+   `operate.utils.gnosis.swap_owner` directly because that helper signs
+   directly as an EOA owner of the service Safe, but after `terminate`
+   the service Safe's owner is the quickstart master Safe (a contract).
+   We use the Safe-A-controlling-Safe-B `approveHash + execTransaction`
+   pattern instead — see `swap_service_safe_owner`.
+
+Post-condition reads: BOTH operations are followed by an on-chain state
+read to confirm success. Gnosis Safe's `execTransaction` does NOT revert
+the outer Ethereum transaction when the inner call fails — it emits an
+`ExecutionFailure` event and returns `false`, so a `tx.status == 1`
+receipt is NOT proof the swap/transfer actually happened. Without these
+post-condition checks the migration would log success while leaving the
+service uncontrollable from Pearl, and `rename_source_for_rollback`
+would then erase the quickstart side — unrecoverable for the user.
+
+Outcomes per operation, in order of severity:
+
+  1. `send_safe_txs` raises before mining (outer-tx revert, gas estimate
+     refusal, signing error) — bubbles up unwrapped as whatever the
+     middleware raised. Nothing on-chain happened.
+  2. Outer tx mines AND post-condition read confirms inner success —
+     function returns the tx hash.
+  3. Outer tx mines but the post-condition shows the inner call reverted
+     (Gnosis Safe's `ExecutionFailure` event; receipt status is still 1
+     because Safe doesn't bubble the inner failure) — `RuntimeError`
+     with the explicit "inner call likely reverted" message. The qs side
+     still owns the asset; safe to investigate.
+  4. Outer tx mines but the post-condition read itself fails after
+     retries — `PostConditionUnknown`. State is INDETERMINATE; the user
+     must verify on a block explorer before any retry.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+import time
+from typing import TYPE_CHECKING, Callable, TypeVar
+
+import requests.exceptions
+import web3.exceptions
 
 if TYPE_CHECKING:
     from aea.crypto.base import Crypto, LedgerApi
+
+
+T = TypeVar("T")
+
+
+# Exception classes that represent transient RPC / network failures. Computed
+# once at module load: these libraries are hard transitive deps (web3 is used
+# directly two functions below; requests is web3's HTTPProvider transport),
+# so an ImportError here is a real misconfiguration that should fail loud at
+# import time, not silently fall back to a narrower retry net.
+#
+# Programming bugs (TypeError, AttributeError, NameError) and post-condition
+# shape mismatches must propagate immediately so the user gets a real
+# traceback instead of `PostConditionUnknown`'s "verify on a block explorer"
+# framing — that framing only makes sense when the failure is actually
+# network-shaped.
+#
+# `asyncio.TimeoutError` is included for Python 3.10 (where it's a distinct
+# subclass of Exception); on 3.11+ it's an alias for the builtin and the
+# duplicate entry is idempotent.
+_RPC_EXCEPTION_TYPES: tuple = (
+    ConnectionError,
+    TimeoutError,
+    asyncio.TimeoutError,
+    OSError,
+    web3.exceptions.Web3Exception,
+    requests.exceptions.RequestException,
+)
+
+
+class PostConditionUnknown(RuntimeError):
+    """Post-condition read could not be completed despite retries.
+
+    On-chain state is INDETERMINATE. `send_safe_txs` returned a tx hash
+    (the outer Ethereum tx mined with status == 1), but for Safe
+    `execTransaction` that ONLY means the outer call ran — the inner
+    call may have emitted `ExecutionFailure` and returned `false`
+    without bubbling up. The verification read that would have told us
+    which (`ownerOf` for the NFT, `getOwners` for the swap) failed
+    repeatedly, so we genuinely don't know whether the inner call
+    landed.
+
+    Distinct from a clean RuntimeError ("post-condition mismatch =
+    inner call reverted") so the caller can stop the migration without
+    re-running blindly — a re-run when the on-chain side already
+    succeeded would fail with `ERC721: caller not owner` (transfer) or
+    GS026/stale-prev-owner (swap), and the user would chase the wrong
+    root cause.
+    """
+
+    def __init__(self, tx_hash: str, last_exc: BaseException) -> None:
+        super().__init__(
+            f"On-chain state INDETERMINATE after Safe tx {tx_hash}: the "
+            f"outer tx mined, but the post-tx verification read failed "
+            f"after retries ({last_exc!r}). DO NOT re-run blindly. "
+            f"To diagnose: (1) inspect Safe's `ExecutionSuccess` / "
+            f"`ExecutionFailure` event at tx {tx_hash} on a block "
+            "explorer, (2) read the post-condition directly — "
+            "`ServiceRegistry.ownerOf(tokenId)` for an NFT transfer or "
+            "`Safe.getOwners()` for a service-Safe swap. Re-run the "
+            "migration only after confirming the inner call did NOT land."
+        )
+        self.tx_hash = tx_hash
+        self.last_exc = last_exc
+
+
+def _read_with_retry(
+    fn: "Callable[[], T]",
+    *,
+    tx_hash: str,
+    attempts: int = 3,
+    backoff: float = 0.5,
+) -> T:
+    """Run `fn()` up to `attempts` times.
+
+    Between attempts, sleeps `backoff * 2**n` where `n` is the
+    failed-attempt index starting at 0; no sleep after the final
+    attempt. Default `attempts=3, backoff=0.5` -> sleeps 0.5s, 1.0s.
+
+    Catches only RPC/network-shaped exceptions (see
+    `_RPC_EXCEPTION_TYPES`). Programming bugs (`TypeError`,
+    `AttributeError`, `NameError`, `ValueError` from a wrong arg
+    shape) propagate immediately so the user sees a real traceback
+    instead of `PostConditionUnknown`'s "verify on block explorer"
+    framing — that framing only makes sense when the failure is
+    actually network-shaped.
+
+    On exhaustion, re-raises wrapped in `PostConditionUnknown` so the
+    caller can distinguish "inner call reverted" from "we don't know".
+    """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+    last_exc: BaseException
+    for n in range(attempts):
+        try:
+            return fn()
+        except _RPC_EXCEPTION_TYPES as exc:
+            last_exc = exc
+            if n + 1 < attempts:
+                time.sleep(backoff * (2 ** n))
+    raise PostConditionUnknown(tx_hash=tx_hash, last_exc=last_exc)
 
 
 def transfer_service_nft(
@@ -57,13 +192,31 @@ def transfer_service_nft(
         abi_element_identifier="transferFrom",
         args=[qs_master_safe, pearl_master_safe, int(service_id)],
     )
-    return send_safe_txs(
+    tx_hash = send_safe_txs(
         txd=bytes.fromhex(txd_hex[2:]),
         safe=qs_master_safe,
         ledger_api=ledger_api,
         crypto=crypto,
         to=service_registry_address,
     )
+
+    # Post-condition: the outer tx mining with status=1 is NOT proof the
+    # NFT moved — Gnosis Safe's execTransaction returns success even when
+    # the inner call reverts (ExecutionFailure event). Re-read ownerOf
+    # and verify it landed on the Pearl Safe. Retry the read so a
+    # transient RPC hiccup post-mining doesn't get reported as a transfer
+    # failure (the tx is already on-chain — re-running would double-submit).
+    new_owner = _read_with_retry(
+        lambda: instance.functions.ownerOf(int(service_id)).call(),
+        tx_hash=tx_hash,
+    )
+    if new_owner.lower() != pearl_master_safe.lower():
+        raise RuntimeError(
+            f"NFT transfer reported success (tx {tx_hash}) but ServiceRegistry "
+            f"still reports owner={new_owner}, expected {pearl_master_safe}. "
+            "Inner call likely reverted (check Safe's ExecutionFailure event)."
+        )
+    return tx_hash
 
 
 def swap_service_safe_owner(
@@ -107,6 +260,7 @@ def swap_service_safe_owner(
     )
     from operate.utils.gnosis import (
         SafeOperation,
+        get_owners,
         get_prev_owner,
         send_safe_txs,
     )
@@ -168,10 +322,30 @@ def swap_service_safe_owner(
             ),
         ],
     )
-    send_safe_txs(
+    exec_tx_hash = send_safe_txs(
         txd=bytes.fromhex(exec_data_hex[2:]),
         safe=old_owner,
         ledger_api=ledger_api,
         crypto=crypto,
         to=service_safe,
     )
+
+    # Post-condition: as with `transfer_service_nft`, the outer tx mining
+    # is NOT proof the swap landed — Safe's execTransaction emits
+    # ExecutionFailure and returns false on inner-call revert without
+    # bubbling up. Re-read getOwners() and verify the swap. Retry the
+    # read so a transient RPC hiccup post-mining doesn't surface as
+    # "swap failed" when the on-chain side actually completed.
+    owners_after = {
+        o.lower() for o in _read_with_retry(
+            lambda: get_owners(ledger_api=ledger_api, safe=service_safe),
+            tx_hash=exec_tx_hash,
+        )
+    }
+    if new_owner.lower() not in owners_after or old_owner.lower() in owners_after:
+        raise RuntimeError(
+            f"swapOwner reported success (tx {exec_tx_hash}) but service Safe "
+            f"{service_safe} still has owners {sorted(owners_after)}. "
+            f"Expected {new_owner} present and {old_owner} absent. Inner call "
+            "likely reverted (check Safe's ExecutionFailure event for the hash)."
+        )

--- a/scripts/pearl_migration/transfer.py
+++ b/scripts/pearl_migration/transfer.py
@@ -79,37 +79,97 @@ def swap_service_safe_owner(
     service multisig after `terminate` swapped agents -> master Safe);
     `crypto` is the master EOA that owns the quickstart master Safe.
 
-    We can NOT use `operate.utils.gnosis.swap_owner` here: that helper
-    sends the swap as a Safe tx originated by `service_safe` itself
-    signed by `crypto` directly, which only validates if `crypto` is an
-    EOA owner of `service_safe`. After terminate the service Safe's
-    owner is the qs master Safe (a contract), so signing as the EOA
-    fails Gnosis Safe signature checks (GS026) and the tx silently
-    reverts on-chain — the migration script logs success because the
-    failure happens in the receipt, not the submit.
+    Two on-chain transactions, both originated by the qs master Safe and
+    signed by the master EOA. This mirrors operate's
+    `EthSafeTxBuilder.get_safe_b_native_transfer_messages` Safe-A-
+    controlling-Safe-B pattern (protocol.py:get_safe_b_native_transfer_messages),
+    adapted for a swapOwner inner instead of a value transfer.
 
-    Correct path mirrors `transfer_service_nft`: build the swapOwner
-    calldata against `service_safe`, then send it as a Safe tx
-    originated by the qs master Safe (which IS an owner of
-    `service_safe`) and signed by the master EOA (which IS an owner of
-    the qs master Safe).
+    Why we can't just call swapOwner from the qs master Safe directly:
+    Gnosis Safe's `swapOwner` has `authorized` requiring
+    `msg.sender == address(this)`. It MUST go through the service
+    Safe's own `execTransaction`. Since the service Safe's only owner
+    is a contract (the qs master Safe), the qs master Safe authorizes
+    that `execTransaction` via the on-chain `approveHash` path:
+
+      1) qs_master_safe -> service_safe.approveHash(inner_tx_hash)
+         (registers qs_master_safe as having pre-approved the hash).
+      2) qs_master_safe -> service_safe.execTransaction(<swapOwner args>,
+         signatures=packed_approved_hash(qs_master_safe))
+         (Safe's signature check sees the approved-hash signature,
+         looks up approvedHashes[qs_master_safe][inner_tx_hash] == 1,
+         and proceeds. The inner call is a self-call into swapOwner,
+         which then sees msg.sender == address(this).)
     """
     from autonomy.chain.base import registry_contracts
-    from operate.utils.gnosis import get_prev_owner, send_safe_txs
+    from operate.services.protocol import (
+        get_packed_signature_for_approved_hash,
+    )
+    from operate.utils.gnosis import (
+        SafeOperation,
+        get_prev_owner,
+        send_safe_txs,
+    )
 
     prev_owner = get_prev_owner(
         ledger_api=ledger_api, safe=service_safe, owner=old_owner,
     )
-    instance = registry_contracts.gnosis_safe.get_instance(
+    service_safe_instance = registry_contracts.gnosis_safe.get_instance(
         ledger_api=ledger_api,
         contract_address=service_safe,
     )
-    txd_hex = instance.encode_abi(
+    swap_owner_data_hex = service_safe_instance.encode_abi(
         abi_element_identifier="swapOwner",
         args=[prev_owner, old_owner, new_owner],
     )
+    swap_owner_data = bytes.fromhex(swap_owner_data_hex[2:])
+
+    # Hash of the inner Safe tx that the service Safe will execute on
+    # itself. Must match the parameters passed to execTransaction below.
+    inner_tx_hash_hex = registry_contracts.gnosis_safe.get_raw_safe_transaction_hash(
+        ledger_api=ledger_api,
+        contract_address=service_safe,
+        to_address=service_safe,
+        value=0,
+        data=swap_owner_data,
+        operation=SafeOperation.CALL.value,
+        safe_tx_gas=0,
+    ).get("tx_hash")
+
+    # Step 1: qs master Safe -> service Safe.approveHash(inner_tx_hash).
+    approve_hash_data_hex = service_safe_instance.encode_abi(
+        abi_element_identifier="approveHash",
+        args=[inner_tx_hash_hex],
+    )
     send_safe_txs(
-        txd=bytes.fromhex(txd_hex[2:]),
+        txd=bytes.fromhex(approve_hash_data_hex[2:]),
+        safe=old_owner,
+        ledger_api=ledger_api,
+        crypto=crypto,
+        to=service_safe,
+    )
+
+    # Step 2: qs master Safe -> service Safe.execTransaction(...) with a
+    # packed approved-hash signature pointing back at the qs master Safe.
+    exec_data_hex = service_safe_instance.encode_abi(
+        abi_element_identifier="execTransaction",
+        args=[
+            service_safe,                             # to (self-call)
+            0,                                        # value
+            swap_owner_data,                          # data
+            SafeOperation.CALL.value,                 # operation
+            0,                                        # safeTxGas
+            0,                                        # baseGas
+            0,                                        # gasPrice
+            "0x" + "00" * 20,                         # gasToken
+            "0x" + "00" * 20,                         # refundReceiver
+            get_packed_signature_for_approved_hash(
+                owners=(old_owner,),
+            ),
+        ],
+    )
+    send_safe_txs(
+        txd=bytes.fromhex(exec_data_hex[2:]),
         safe=old_owner,
         ledger_api=ledger_api,
         crypto=crypto,

--- a/scripts/pearl_migration/transfer.py
+++ b/scripts/pearl_migration/transfer.py
@@ -75,15 +75,43 @@ def swap_service_safe_owner(
 ) -> None:
     """Replace `old_owner` with `new_owner` on `service_safe`.
 
-    Thin wrapper over `operate.utils.gnosis.swap_owner` so callers don't need
-    to import middleware internals.
-    """
-    from operate.utils.gnosis import swap_owner
+    `old_owner` is the quickstart master Safe (a contract owner of the
+    service multisig after `terminate` swapped agents -> master Safe);
+    `crypto` is the master EOA that owns the quickstart master Safe.
 
-    swap_owner(
+    We can NOT use `operate.utils.gnosis.swap_owner` here: that helper
+    sends the swap as a Safe tx originated by `service_safe` itself
+    signed by `crypto` directly, which only validates if `crypto` is an
+    EOA owner of `service_safe`. After terminate the service Safe's
+    owner is the qs master Safe (a contract), so signing as the EOA
+    fails Gnosis Safe signature checks (GS026) and the tx silently
+    reverts on-chain — the migration script logs success because the
+    failure happens in the receipt, not the submit.
+
+    Correct path mirrors `transfer_service_nft`: build the swapOwner
+    calldata against `service_safe`, then send it as a Safe tx
+    originated by the qs master Safe (which IS an owner of
+    `service_safe`) and signed by the master EOA (which IS an owner of
+    the qs master Safe).
+    """
+    from autonomy.chain.base import registry_contracts
+    from operate.utils.gnosis import get_prev_owner, send_safe_txs
+
+    prev_owner = get_prev_owner(
+        ledger_api=ledger_api, safe=service_safe, owner=old_owner,
+    )
+    instance = registry_contracts.gnosis_safe.get_instance(
+        ledger_api=ledger_api,
+        contract_address=service_safe,
+    )
+    txd_hex = instance.encode_abi(
+        abi_element_identifier="swapOwner",
+        args=[prev_owner, old_owner, new_owner],
+    )
+    send_safe_txs(
+        txd=bytes.fromhex(txd_hex[2:]),
+        safe=old_owner,
         ledger_api=ledger_api,
         crypto=crypto,
-        safe=service_safe,
-        old_owner=old_owner,
-        new_owner=new_owner,
+        to=service_safe,
     )

--- a/scripts/pearl_migration/transfer.py
+++ b/scripts/pearl_migration/transfer.py
@@ -1,0 +1,89 @@
+"""On-chain transfers signed by the quickstart master Safe.
+
+Two operations are needed in Mode B per service per chain:
+
+1. **NFT transfer** — call `transferFrom(from, to, tokenId)` on the chain's
+   ServiceRegistry to move the on-chain service NFT from the quickstart master
+   Safe to the Pearl master Safe. This is the only piece without an existing
+   middleware helper; we encode the ABI call here and dispatch through
+   `operate.utils.gnosis.send_safe_txs`.
+
+   We deliberately use `transferFrom`, not `safeTransferFrom`. The "safe"
+   variant calls `onERC721Received` on the recipient — which a Gnosis Safe
+   only implements if it has the `CompatibilityFallbackHandler` (or
+   equivalent ERC-721 receiver) installed. Pearl Safes created by the
+   middleware do install it, but a freshly-created Safe without it would
+   revert with an opaque `execution reverted`. Both endpoints here are
+   Safes we control end-to-end, so the receiver hook adds no real safety.
+
+2. **Service-Safe owner swap** — replace the quickstart master Safe with the
+   Pearl master Safe in the service multisig's owner list. Reuses
+   `operate.utils.gnosis.swap_owner` directly.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aea.crypto.base import Crypto, LedgerApi
+
+
+def transfer_service_nft(
+    ledger_api: "LedgerApi",
+    crypto: "Crypto",
+    service_registry_address: str,
+    qs_master_safe: str,
+    pearl_master_safe: str,
+    service_id: int,
+) -> str:
+    """Transfer the ERC721 service NFT from `qs_master_safe` to `pearl_master_safe`.
+
+    The tx is composed as a Safe transaction originated by `qs_master_safe`,
+    targeting the ServiceRegistry contract. `crypto` must belong to one of the
+    Safe's owners (the quickstart master EOA).
+
+    Returns the transaction hash from `send_safe_txs`. Raises on chain errors.
+    """
+    from autonomy.chain.base import registry_contracts
+    from operate.utils.gnosis import send_safe_txs
+
+    instance = registry_contracts.service_registry.get_instance(
+        ledger_api=ledger_api,
+        contract_address=service_registry_address,
+    )
+    # `transferFrom` (not `safeTransferFrom`): see module docstring for why.
+    txd_hex = instance.encode_abi(
+        abi_element_identifier="transferFrom",
+        args=[qs_master_safe, pearl_master_safe, int(service_id)],
+    )
+    return send_safe_txs(
+        txd=bytes.fromhex(txd_hex[2:]),
+        safe=qs_master_safe,
+        ledger_api=ledger_api,
+        crypto=crypto,
+        to=service_registry_address,
+    )
+
+
+def swap_service_safe_owner(
+    ledger_api: "LedgerApi",
+    crypto: "Crypto",
+    service_safe: str,
+    old_owner: str,
+    new_owner: str,
+) -> None:
+    """Replace `old_owner` with `new_owner` on `service_safe`.
+
+    Thin wrapper over `operate.utils.gnosis.swap_owner` so callers don't need
+    to import middleware internals.
+    """
+    from operate.utils.gnosis import swap_owner
+
+    swap_owner(
+        ledger_api=ledger_api,
+        crypto=crypto,
+        safe=service_safe,
+        old_owner=old_owner,
+        new_owner=new_owner,
+    )

--- a/scripts/pearl_migration/wallet.py
+++ b/scripts/pearl_migration/wallet.py
@@ -83,7 +83,16 @@ def align_quickstart_password(
 
         if keys_dir.exists():
             re_encrypted = 0
-            for key_path in keys_dir.iterdir():
+            # Snapshot the listing before in-place mutation: each
+            # `_reencrypt_agent_key` does an atomic rename over the original
+            # keyfile. POSIX doesn't guarantee `iterdir`'s underlying
+            # `scandir` stream behavior across rename-over-self, and some
+            # FUSE / network mounts (CIFS, certain SMB clients) re-yield
+            # the renamed entry — which would feed an already-rotated key
+            # back through `_reencrypt_agent_key` with `old_password` and
+            # raise `DecryptError`, forcing the user onto the manual
+            # snapshot-recovery path on a happy-path rotation.
+            for key_path in list(keys_dir.iterdir()):
                 if not key_path.is_file():
                     continue
                 # Skip `.tmp` partial-write artifacts and operate's own

--- a/scripts/pearl_migration/wallet.py
+++ b/scripts/pearl_migration/wallet.py
@@ -15,13 +15,23 @@ the rest of the migration treats agent keys as opaque blobs.
 
 Mode A never hits this — it copies qs into a fresh Pearl store, so Pearl
 inherits qs's password by construction.
+
+Crash safety: a snapshot of `wallets/` and `keys/` is taken before any
+mutation. On any failure during re-encryption, the snapshot directory
+path is included in the raised exception so the user has a concrete
+recovery command. The snapshot is NEVER auto-deleted — on success the
+user may remove it once Pearl has launched; on failure it is the only
+recovery artifact, so removing it before the issue is resolved would
+be unrecoverable.
 """
 from __future__ import annotations
 
 import json
+import shutil
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-from .prompts import info, warn
+from .prompts import backup_suffix, info, warn
 
 if TYPE_CHECKING:
     from operate.app import OperateApp
@@ -35,65 +45,87 @@ def align_quickstart_password(
 ) -> None:
     """Re-encrypt qs's master keyfile + every agent key with `new_password`.
 
-    Mutates `qs_app.password` and `qs_wallet`'s on-disk keyfile in place.
-    Idempotent when `qs_app.password == new_password` (no-op).
+    Mutates `qs_app.password`, the keys manager's password, and qs's
+    on-disk keyfiles in place. Idempotent when `qs_app.password ==
+    new_password` (no-op).
     """
-    from eth_account import Account
+    # Capture old password BEFORE any mutation. `qs_wallet.update_password`
+    # writes through to `qs_app.password` (wallets share state via the
+    # wallet manager), so reading after the master-keyfile rotate would
+    # silently surface as a `DecryptError` on every agent key.
+    old_password = qs_app.password
 
-    if qs_app.password == new_password:
+    if old_password == new_password:
         info("  quickstart and Pearl already share a master password.")
         return
 
-    info("  re-encrypting quickstart master keyfile with Pearl's password...")
-    # Operate's `update_password` re-encrypts the master keyfile and updates
-    # the in-memory wallet password; covers the master EOA case.
-    qs_wallet.update_password(new_password)
-
-    # Now walk the keys directory and re-encrypt each agent key. The keys
-    # manager wraps each file as an operate `Key` (ledger / address /
-    # private_key), where private_key holds the JSON-encoded eth_account
-    # keyfile encrypted with the master password.
     keys_manager = qs_app.keys_manager
-    keys_dir = keys_manager.path
+    keys_dir: Path = keys_manager.path
+    wallets_dir: Path = qs_wallet.path
+
+    # Snapshot wallets/ and keys/ to a timestamped sibling under the
+    # qs `.operate/`. If anything below this point fails the user has
+    # a concrete recovery path printed in the exception message — there
+    # is otherwise NO way back: the master keyfile is rotated to Pearl's
+    # password, agent keys are atomically replaced, and operate doesn't
+    # cache the old plaintext anywhere.
+    snapshot_dir = wallets_dir.parent / f".pre-align.{backup_suffix()}"
+    snapshot_dir.mkdir(parents=True, exist_ok=False)
+    if wallets_dir.exists():
+        shutil.copytree(wallets_dir, snapshot_dir / wallets_dir.name, symlinks=True)
     if keys_dir.exists():
-        old_password = qs_app.password
-        keys_manager.password = old_password  # explicit: decrypt with old
-        re_encrypted = 0
-        for key_path in keys_dir.iterdir():
-            if not key_path.is_file() or key_path.suffix == ".bak":
-                continue
-            try:
+        shutil.copytree(keys_dir, snapshot_dir / keys_dir.name, symlinks=True)
+    info(f"  pre-align snapshot: {snapshot_dir}")
+
+    try:
+        info("  re-encrypting quickstart master keyfile with Pearl's password...")
+        qs_wallet.update_password(new_password)
+
+        if keys_dir.exists():
+            re_encrypted = 0
+            for key_path in keys_dir.iterdir():
+                if not key_path.is_file():
+                    continue
+                # Skip `.tmp` partial-write artifacts and operate's own
+                # `.bak` siblings. Defensive — snapshot-based recovery is
+                # the normal path; this only fires if a foreign writer
+                # left a stray sibling we'd otherwise try to parse as a
+                # keyfile and abort the whole walk.
+                if key_path.suffix == ".tmp":
+                    warn(f"  ignored stale partial-write artifact: {key_path}")
+                    continue
+                if key_path.suffix == ".bak":
+                    continue
                 _reencrypt_agent_key(
                     key_path=key_path,
-                    keys_manager=keys_manager,
                     old_password=old_password,
                     new_password=new_password,
-                    Account=Account,
                 )
                 re_encrypted += 1
-            except Exception as exc:  # pylint: disable=broad-except
-                warn(
-                    f"  failed to re-encrypt {key_path.name}: {exc}. "
-                    "Restore the .bak sibling and rerun the migration."
-                )
-                raise
-        info(f"  re-encrypted {re_encrypted} agent key(s) with Pearl's password.")
+            info(f"  re-encrypted {re_encrypted} agent key(s) with Pearl's password.")
 
-    # All keyfiles on qs/ side now use Pearl's password. Plumb that through
-    # so subsequent operate calls (signing, key lookup, deploy) authenticate.
-    qs_app.password = new_password
-    keys_manager.password = new_password
+        # All keyfiles on qs/ side now use Pearl's password. Plumb through
+        # so subsequent operate calls authenticate against the new password.
+        qs_app.password = new_password
+        keys_manager.password = new_password
+    except Exception as exc:  # pylint: disable=broad-except
+        warn(
+            f"  failed to re-encrypt qs wallet: {exc}. "
+            f"Recover with: rm -rf {wallets_dir} {keys_dir} && "
+            f"mv {snapshot_dir}/{wallets_dir.name} {wallets_dir} && "
+            f"mv {snapshot_dir}/{keys_dir.name} {keys_dir}"
+        )
+        raise
 
 
 def _reencrypt_agent_key(
     *,
-    key_path,
-    keys_manager,
+    key_path: Path,
     old_password: str,
     new_password: str,
-    Account,
 ) -> None:
     """Decrypt with `old_password`, re-encrypt with `new_password`, atomic."""
+    from eth_account import Account
     from operate.keys import Key
 
     key = Key.from_json(  # type: ignore[attr-defined]
@@ -101,7 +133,7 @@ def _reencrypt_agent_key(
     )
     decrypted = key.get_decrypted_json(old_password)
     raw_pk_hex = decrypted["private_key"]
-    if raw_pk_hex.startswith("0x") or raw_pk_hex.startswith("0X"):
+    if raw_pk_hex.startswith(("0x", "0X")):
         raw_pk_hex = raw_pk_hex[2:]
     raw_pk = bytes.fromhex(raw_pk_hex)
 

--- a/scripts/pearl_migration/wallet.py
+++ b/scripts/pearl_migration/wallet.py
@@ -105,6 +105,14 @@ def align_quickstart_password(
                     continue
                 if key_path.suffix == ".bak":
                     continue
+                # Skip dotfiles (`.DS_Store` from macOS Finder, editor
+                # swap files, etc.). Real agent keys are named after the
+                # Ethereum address (`0x{40-hex}`), so a leading dot
+                # never matches a legitimate keyfile — feeding one to
+                # `_reencrypt_agent_key` would crash at `json.loads()`
+                # and abort the whole rotation.
+                if key_path.name.startswith("."):
+                    continue
                 _reencrypt_agent_key(
                     key_path=key_path,
                     old_password=old_password,

--- a/scripts/pearl_migration/wallet.py
+++ b/scripts/pearl_migration/wallet.py
@@ -1,0 +1,119 @@
+"""Quickstart wallet password alignment for Mode B merges.
+
+Mode B merges qs/.operate into an existing Pearl/.operate. The two stores
+may have been initialised with different master passwords. After the
+merge, Pearl's keys manager — which uses Pearl's master password — must
+be able to decrypt every agent key it now sees. A verbatim copy of qs's
+agent keyfiles leaves them encrypted with qs's password and breaks the
+first deploy with `DecryptError: Decrypt error! Bad password?`.
+
+Rather than carrying two passwords through `merge_service` and re-keying
+files mid-copy, we re-encrypt the qs store IN PLACE before merging:
+qs's master keyfile and every key under qs/.operate/keys/ get re-encrypted
+with Pearl's password. After this step qs and Pearl share a password and
+the rest of the migration treats agent keys as opaque blobs.
+
+Mode A never hits this — it copies qs into a fresh Pearl store, so Pearl
+inherits qs's password by construction.
+"""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from .prompts import info, warn
+
+if TYPE_CHECKING:
+    from operate.app import OperateApp
+    from operate.wallet.master import MasterWallet
+
+
+def align_quickstart_password(
+    qs_app: "OperateApp",
+    qs_wallet: "MasterWallet",
+    new_password: str,
+) -> None:
+    """Re-encrypt qs's master keyfile + every agent key with `new_password`.
+
+    Mutates `qs_app.password` and `qs_wallet`'s on-disk keyfile in place.
+    Idempotent when `qs_app.password == new_password` (no-op).
+    """
+    from eth_account import Account
+
+    if qs_app.password == new_password:
+        info("  quickstart and Pearl already share a master password.")
+        return
+
+    info("  re-encrypting quickstart master keyfile with Pearl's password...")
+    # Operate's `update_password` re-encrypts the master keyfile and updates
+    # the in-memory wallet password; covers the master EOA case.
+    qs_wallet.update_password(new_password)
+
+    # Now walk the keys directory and re-encrypt each agent key. The keys
+    # manager wraps each file as an operate `Key` (ledger / address /
+    # private_key), where private_key holds the JSON-encoded eth_account
+    # keyfile encrypted with the master password.
+    keys_manager = qs_app.keys_manager
+    keys_dir = keys_manager.path
+    if keys_dir.exists():
+        old_password = qs_app.password
+        keys_manager.password = old_password  # explicit: decrypt with old
+        re_encrypted = 0
+        for key_path in keys_dir.iterdir():
+            if not key_path.is_file() or key_path.suffix == ".bak":
+                continue
+            try:
+                _reencrypt_agent_key(
+                    key_path=key_path,
+                    keys_manager=keys_manager,
+                    old_password=old_password,
+                    new_password=new_password,
+                    Account=Account,
+                )
+                re_encrypted += 1
+            except Exception as exc:  # pylint: disable=broad-except
+                warn(
+                    f"  failed to re-encrypt {key_path.name}: {exc}. "
+                    "Restore the .bak sibling and rerun the migration."
+                )
+                raise
+        info(f"  re-encrypted {re_encrypted} agent key(s) with Pearl's password.")
+
+    # All keyfiles on qs/ side now use Pearl's password. Plumb that through
+    # so subsequent operate calls (signing, key lookup, deploy) authenticate.
+    qs_app.password = new_password
+    keys_manager.password = new_password
+
+
+def _reencrypt_agent_key(
+    *,
+    key_path,
+    keys_manager,
+    old_password: str,
+    new_password: str,
+    Account,
+) -> None:
+    """Decrypt with `old_password`, re-encrypt with `new_password`, atomic."""
+    from operate.keys import Key
+
+    key = Key.from_json(  # type: ignore[attr-defined]
+        obj=json.loads(key_path.read_text(encoding="utf-8")),
+    )
+    decrypted = key.get_decrypted_json(old_password)
+    raw_pk_hex = decrypted["private_key"]
+    if raw_pk_hex.startswith("0x") or raw_pk_hex.startswith("0X"):
+        raw_pk_hex = raw_pk_hex[2:]
+    raw_pk = bytes.fromhex(raw_pk_hex)
+
+    new_keyfile = Account.encrypt(raw_pk, new_password)
+    new_key = Key(  # type: ignore[call-arg]
+        ledger=key.ledger,
+        address=key.address,
+        private_key=json.dumps(new_keyfile),
+    )
+
+    # Atomic write: write to a tmp sibling and rename. A crash mid-write
+    # would otherwise leave the keyfile truncated and unrecoverable.
+    tmp_path = key_path.with_suffix(key_path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(new_key.json), encoding="utf-8")
+    tmp_path.replace(key_path)

--- a/scripts/pearl_migration/wallet.py
+++ b/scripts/pearl_migration/wallet.py
@@ -34,8 +34,69 @@ from typing import TYPE_CHECKING
 from .prompts import backup_suffix, info, warn
 
 if TYPE_CHECKING:
-    from operate.app import OperateApp
+    from operate.cli import OperateApp
     from operate.wallet.master import MasterWallet
+
+
+def align_user_account_to_wallet(operate_app: "OperateApp") -> None:
+    """Force `user.json`'s hash to match `operate_app.password`.
+
+    Quickstart's normal flow assumes `user.json`'s password and the
+    master-wallet keyfile's password are always the same — but on some
+    installs they diverge (legacy create-then-import, partial setup,
+    manual rotation). `_load_wallet` validates against the wallet keyfile,
+    so a diverged `user.json` is silent on entry. Then every middleware
+    function that calls `ask_password_if_needed` validates against
+    `user.json` and unconditionally runs `operate.password = <input>`,
+    overwriting our wallet-validated password with the user-account one.
+    Subsequent signing ops then `DecryptError` (flattened by
+    `OnChainHelper.load_crypto` to "Cannot load private key for following
+    possible reasons - Wrong key format - Wrong key length - Trailing
+    spaces or new line characters").
+
+    Force-rewrite `user.json`'s hash to the wallet password we validated,
+    so middleware's password handling stays internally consistent. The
+    wallet keyfile is untouched: the user's password is still what they
+    typed at `_load_wallet`. The pre-existing `user.json` hash is
+    overwritten by the new one — callers are responsible for ensuring
+    that's acceptable for the operate store in question (the migration
+    flow only invokes this on stores it owns end-to-end). Skips cleanly
+    when `user.json` is absent — middleware's create-new-user branch
+    in `ask_password_if_needed` will create one with whatever password
+    is supplied (we plumb `OPERATE_PASSWORD` env var in
+    `stop_via_middleware` so that "whatever" is the wallet password).
+
+    Called from two sites: `_load_wallet` (initial password establish)
+    and the tail of `align_quickstart_password` (re-rotation to Pearl's
+    password — wallet/keys are rotated there, user.json must follow or
+    it'd diverge again).
+    """
+    ua = operate_app.user_account
+    if ua is None:
+        return
+    if operate_app.password is None:
+        # `_load_wallet` fatals on a bad password and
+        # `align_quickstart_password` always sets `qs_app.password` to
+        # the new password before this is called — so reaching here
+        # means a future caller invoked us before establishing the
+        # wallet password. Raise rather than warn-and-continue: a
+        # silent skip would leave `user.json` diverged and resurface
+        # as the original "Cannot load private key" failure deep in
+        # middleware, which is exactly the regression this helper is
+        # meant to prevent.
+        raise AssertionError(
+            "align_user_account_to_wallet called with operate_app.password "
+            "unset. This is a programming error — every caller must "
+            "validate the wallet password before invoking alignment."
+        )
+    if ua.is_valid(operate_app.password):
+        return
+    info(
+        "  detected user.json password ≠ wallet password; aligning "
+        "user.json hash to the wallet password to keep middleware "
+        "operations consistent."
+    )
+    ua.force_update(operate_app.password)
 
 
 def align_quickstart_password(
@@ -131,6 +192,30 @@ def align_quickstart_password(
             f"Recover with: rm -rf {wallets_dir} {keys_dir} && "
             f"mv {snapshot_dir}/{wallets_dir.name} {wallets_dir} && "
             f"mv {snapshot_dir}/{keys_dir.name} {keys_dir}"
+        )
+        raise
+
+    # Wallet + agent keys are fully rotated at this point; `user.json`
+    # is the only remaining piece. Run alignment OUTSIDE the snapshot
+    # try/except so a `force_update` failure (disk full, perms) doesn't
+    # surface the snapshot-recovery message — that message would be
+    # actively misleading here, since restoring `wallets/` and `keys/`
+    # from the snapshot would put them BACK to the old password while
+    # `qs_app.password` is already the new one. The right recovery for
+    # an alignment-only failure is just to re-run the migration; the
+    # wallet+keys are already correct.
+    try:
+        align_user_account_to_wallet(qs_app)
+    except Exception as exc:  # pylint: disable=broad-except
+        warn(
+            f"  wallet and agent keys rotated successfully, but updating "
+            f"the user.json hash failed: {exc}. The qs `user.json` is "
+            f"now out of sync with the wallet password. "
+            f"Recover with: re-run `migrate_to_pearl.sh` — the rotation "
+            f"is idempotent and the alignment will be retried. "
+            f"Do NOT restore from the snapshot at {snapshot_dir} — "
+            f"wallet/keys are already on the new password and a "
+            f"snapshot restore would put them back to the old one."
         )
         raise
 

--- a/tests/test_migrate_to_pearl.py
+++ b/tests/test_migrate_to_pearl.py
@@ -142,6 +142,7 @@ def _spawn_run_service(
         child = pexpect.spawn(
             f"bash ./run_service.sh {config_path}",
             encoding="utf-8", timeout=600, env=spawn_env, cwd=str(cwd),
+            logfile=sys.stdout,
         )
         try:
             while True:
@@ -176,6 +177,7 @@ def _spawn_stop_service(
         child = pexpect.spawn(
             f"bash ./stop_service.sh {config_path}",
             encoding="utf-8", timeout=120, env=spawn_env, cwd=str(cwd),
+            logfile=sys.stdout,
         )
         try:
             while True:

--- a/tests/test_migrate_to_pearl.py
+++ b/tests/test_migrate_to_pearl.py
@@ -93,7 +93,7 @@ def _copy_repo_to(dest: Path, logger: logging.Logger) -> None:
         ".", dest, dirs_exist_ok=True,
         ignore=shutil.ignore_patterns(
             ".operate", ".pytest_cache", "__pycache__",
-            "*.pyc", "logs", "*.log", ".env",
+            "*.pyc", "logs", "*.log", ".env", ".venv",
         ),
     )
     logger.info(f"Copied repo to {dest}")

--- a/tests/test_migrate_to_pearl.py
+++ b/tests/test_migrate_to_pearl.py
@@ -247,6 +247,10 @@ def _spawn_migrate_to_pearl(
         r"\s*Pearl password:\s*$": pearl_password,
         r"Rename the source quickstart `\.operate/` to keep it as a rollback\?": "y",
         r"Do you want to run Pearl on a different machine than this one\?": "n",
+        # Mode B fires this when qs and Pearl have different master passwords;
+        # the e2e exercises that path (qs2 has a distinct password) so we
+        # accept the re-encryption.
+        r"Proceed with re-encryption\?": "y",
     }
 
     def _all_choice(out: str) -> str:

--- a/tests/test_migrate_to_pearl.py
+++ b/tests/test_migrate_to_pearl.py
@@ -1,0 +1,580 @@
+# -*- coding: utf-8 -*-
+"""End-to-end test: two quickstarts × two services each → one Pearl `.operate`.
+
+Mirrors the structure of `test_run_service.py` (pexpect-driven, real docker,
+Tenderly funding) and reuses its helpers. Runs under the `e2e` marker.
+
+Scenario
+--------
+1. Set up two independent quickstart cwds (qs1, qs2). Each is a fresh copy
+   of the repo with its own `.operate` (i.e. its own master wallet).
+2. In each quickstart cwd, deploy two distinct service configs sequentially
+   via `run_service.sh`, then stop them. Result: 4 distinct on-chain
+   services across two stores.
+3. Run `migrate_to_pearl.sh` from qs1 → Pearl `.operate` (Mode A: simple
+   copy because the target home didn't exist yet).
+4. Run `migrate_to_pearl.sh` from qs2 → same Pearl `.operate` (Mode B:
+   merge, including on-chain NFT transfer + Safe owner swap + master
+   wallet drains).
+5. Assert all four service config dirs and their referenced agent keys
+   landed in Pearl's `.operate`.
+6. Spin up the middleware against Pearl's `.operate` and `deploy_service_locally`
+   each migrated service. Verify the ABCI container comes up for each — i.e.
+   they are able to start.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import pexpect
+import pytest
+from dotenv import load_dotenv
+from operate.cli import OperateApp
+from operate.constants import OPERATE
+from operate.operate_types import LedgerType
+
+# Reuse the existing helpers from test_run_service for prompt handling,
+# logging, funding via Tenderly, docker/health checks, and cleanup. Keeping
+# this DRY also keeps behaviour consistent across e2e tests.
+from test_run_service import (
+    CONTAINER_STOP_WAIT,
+    SERVICE_INIT_WAIT,
+    STARTUP_WAIT,
+    check_docker_status,
+    cleanup_directory,
+    ensure_service_stopped,
+    get_config_specific_settings,
+    log_expect_match,
+    send_input_safely,
+    setup_logging,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.integration]
+
+# Single source of truth for env vars: the repo-root `.env`. CI writes it
+# from secrets in the workflow's "Create .env file" step; locally the user
+# maintains it. `os.environ` always wins (`override=False`), so explicit
+# shell exports stay authoritative.
+load_dotenv(Path(__file__).resolve().parent.parent / ".env", override=False)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Two configs per quickstart. Pick the cheapest, fastest two on-chain agents.
+# Using the same two configs for both quickstarts gives 4 distinct services
+# on-chain (different master wallets per quickstart cwd).
+QS_CONFIGS = (
+    "configs/config_predict_trader.json",
+    "configs/config_optimus.json",
+)
+
+MIGRATION_TIMEOUT = 1200  # 20 min — Mode B can include several Safe txs
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _copy_repo_to(dest: Path, logger: logging.Logger) -> None:
+    """Copy the repo into `dest`, excluding heavy/local-only paths."""
+    shutil.copytree(
+        ".", dest, dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns(
+            ".operate", ".pytest_cache", "__pycache__",
+            "*.pyc", "logs", "*.log", ".env",
+        ),
+    )
+    logger.info(f"Copied repo to {dest}")
+
+
+@contextlib.contextmanager
+def _override_test_password(password: Optional[str]) -> Iterator[None]:
+    """Temporarily set `os.environ['TEST_PASSWORD']` for prompt-map building.
+
+    `test_run_service.get_config_specific_settings` reads the env var at
+    call time and bakes it into the prompts dict, so to make a quickstart
+    use a different master password we just swap the var around the call
+    and restore on exit. No effect when `password` is None.
+    """
+    if password is None:
+        yield
+        return
+    original = os.environ.get("TEST_PASSWORD")
+    os.environ["TEST_PASSWORD"] = password
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("TEST_PASSWORD", None)
+        else:
+            os.environ["TEST_PASSWORD"] = original
+
+
+def _spawn_run_service(
+    cwd: Path,
+    config_path: str,
+    env: Dict[str, str],
+    logger: logging.Logger,
+    password: Optional[str] = None,
+) -> None:
+    """Run `./run_service.sh <cfg>` in `cwd`, walking the existing prompt map.
+
+    `password` overrides `TEST_PASSWORD` for the duration of the call (and
+    inside the spawned subprocess), so two quickstarts in the same test
+    can use different master passwords.
+    """
+    with _override_test_password(password):
+        settings = get_config_specific_settings(config_path)
+        spawn_env = {**env, "TEST_PASSWORD": password} if password else env
+        logger.info(f"  -> run_service.sh {config_path} in {cwd}")
+        child = pexpect.spawn(
+            f"bash ./run_service.sh {config_path}",
+            encoding="utf-8", timeout=600, env=spawn_env, cwd=str(cwd),
+        )
+        try:
+            while True:
+                patterns = list(settings["prompts"].keys())
+                idx = child.expect(patterns, timeout=600)
+                pattern = patterns[idx]
+                log_expect_match(child, pattern, idx, logger)
+                response = settings["prompts"][pattern]
+                if callable(response):
+                    output = child.before + child.after
+                    response = response(output, logger)
+                send_input_safely(child, response, logger)
+        except pexpect.EOF:
+            logger.info("  -> run_service.sh completed")
+    time.sleep(SERVICE_INIT_WAIT)
+    if not check_docker_status(logger, config_path):
+        raise RuntimeError(f"Service for {config_path} failed to come up")
+
+
+def _spawn_stop_service(
+    cwd: Path,
+    config_path: str,
+    env: Dict[str, str],
+    logger: logging.Logger,
+    password: Optional[str] = None,
+) -> None:
+    """Stop the deployment for one config in `cwd`."""
+    with _override_test_password(password):
+        settings = get_config_specific_settings(config_path)
+        spawn_env = {**env, "TEST_PASSWORD": password} if password else env
+        logger.info(f"  -> stop_service.sh {config_path} in {cwd}")
+        child = pexpect.spawn(
+            f"bash ./stop_service.sh {config_path}",
+            encoding="utf-8", timeout=120, env=spawn_env, cwd=str(cwd),
+        )
+        try:
+            while True:
+                patterns = list(settings["prompts"].keys())
+                idx = child.expect(patterns, timeout=120)
+                pattern = patterns[idx]
+                log_expect_match(child, pattern, idx, logger)
+                response = settings["prompts"][pattern]
+                if callable(response):
+                    output = child.before + child.after
+                    response = response(output, logger)
+                send_input_safely(child, response, logger)
+        except pexpect.EOF:
+            logger.info("  -> stop_service.sh completed")
+    time.sleep(CONTAINER_STOP_WAIT)
+
+
+def _spawn_migrate_to_pearl(
+    cwd: Path,
+    pearl_home: Path,
+    password: str,
+    pearl_password: str,
+    env: Dict[str, str],
+    logger: logging.Logger,
+) -> None:
+    """Run `./migrate_to_pearl.sh` in `cwd`, answering the prompt sequence.
+
+    Drives both Mode A and Mode B paths transparently — the script is the
+    same; only the password prompts and on-chain steps differ. We always
+    try to answer:
+      * multi-service "Select [1-N]:" → highest number ("all")
+      * collision prompt (shouldn't fire on a happy-path test) → skip ("1")
+      * quickstart password
+      * Pearl password (Mode B only)
+      * Rename source for rollback? → "y"
+      * Run Pearl on a different machine? → "n"
+    """
+    logger.info(
+        f"  -> migrate_to_pearl.sh in {cwd} (pearl_home={pearl_home})"
+    )
+    child = pexpect.spawn(
+        f"bash ./migrate_to_pearl.sh --pearl-home {pearl_home}",
+        encoding="utf-8", timeout=MIGRATION_TIMEOUT, env=env, cwd=str(cwd),
+        logfile=sys.stdout,
+    )
+    # Track which password we're answering next.
+    pw_state = {"asked_qs": False}
+
+    pattern_map = {
+        # multi-service selection: pick the largest number which is "all"
+        r"Select \[1-(\d+)\]:": lambda out, *_: _all_choice(out),
+        r"Choice \[1/2\]:": "1",  # if a collision somehow happened, skip
+        r"\s*quickstart password:\s*$": password,
+        r"\s*Pearl password:\s*$": pearl_password,
+        r"Rename the source quickstart `\.operate/` to keep it as a rollback\?": "y",
+        r"Do you want to run Pearl on a different machine than this one\?": "n",
+    }
+
+    def _all_choice(out: str) -> str:
+        import re
+        m = re.search(r"Select \[1-(\d+)\]:", out)
+        return m.group(1) if m else "1"
+
+    try:
+        while True:
+            patterns = list(pattern_map.keys())
+            idx = child.expect(patterns, timeout=MIGRATION_TIMEOUT)
+            pattern = patterns[idx]
+            log_expect_match(child, pattern, idx, logger)
+            resp = pattern_map[pattern]
+            if callable(resp):
+                out = child.before + child.after
+                resp = resp(out, logger)
+            send_input_safely(child, resp, logger)
+            if "quickstart password" in pattern:
+                pw_state["asked_qs"] = True
+    except pexpect.EOF:
+        logger.info("  -> migrate_to_pearl.sh completed")
+
+
+def _list_pearl_services(pearl_home: Path) -> List[Path]:
+    services_dir = pearl_home / "services"
+    if not services_dir.exists():
+        return []
+    return sorted(p for p in services_dir.iterdir() if p.name.startswith("sc-"))
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+class TestMigrateToPearlEndToEnd:
+    """4 services across 2 quickstart cwds → 1 Pearl `.operate` → all start.
+
+    State is shared across the four `test_NN_*` methods via class attributes
+    set in `setup_class` (`work_root`, `qs_dirs`, `pearl_home`, `test_env`,
+    `password`). Each step also depends on on-disk state created by the
+    previous step (the per-quickstart `.operate` dirs, then Pearl's `.operate`
+    dir). The `test_NN_*` numbering keeps pytest's default alphabetical order
+    deterministic; running a single step in isolation will fail by design.
+    `_failed` is set on the first failure so subsequent steps short-circuit
+    rather than produce cascading misleading errors.
+    """
+
+    logger: logging.Logger
+    work_root: tempfile.TemporaryDirectory
+    qs_dirs: Tuple[Path, Path]
+    pearl_home: Path
+    test_env: Dict[str, str]
+    password: str          # qs1 master password (and Pearl's, since Pearl
+                           # inherits qs1's wallet via the Mode A copy)
+    qs2_password: str      # qs2's master password — deliberately different,
+                           # so test_03 exercises Mode B with two distinct
+                           # passwords (quickstart vs Pearl).
+    _failed: bool = False
+
+    @classmethod
+    def setup_class(cls) -> None:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        cls.logger = setup_logging(Path(f"test_migrate_to_pearl_{ts}.log"))
+        cls.password = os.getenv("TEST_PASSWORD", "test_secret")
+        # Derive qs2's password from the base password so we don't need a
+        # second secret in CI; the suffix just makes it deterministically
+        # different.
+        cls.qs2_password = f"{cls.password}_qs2"
+
+        cls.work_root = tempfile.TemporaryDirectory(prefix="migrate_to_pearl_e2e_")
+        root = Path(cls.work_root.name)
+
+        # Two independent quickstart cwds (each gets its own .operate / wallet).
+        qs1 = root / "qs1"
+        qs2 = root / "qs2"
+        qs1.mkdir()
+        qs2.mkdir()
+        _copy_repo_to(qs1, cls.logger)
+        _copy_repo_to(qs2, cls.logger)
+
+        # Pearl side gets its own HOME so `~/.operate` (the script default
+        # target) is fully isolated from the developer / CI runner state.
+        pearl_home_root = root / "home"
+        pearl_home_root.mkdir()
+        cls.pearl_home = pearl_home_root / OPERATE  # e.g. <root>/home/.operate
+        cls.qs_dirs = (qs1, qs2)
+
+        # Env shared across all spawned subprocesses. We drop VIRTUAL_ENV so
+        # poetry inside the spawned shell creates / uses its own env, just
+        # like test_run_service does.
+        cls.test_env = os.environ.copy()
+        cls.test_env.pop("VIRTUAL_ENV", None)
+        cls.test_env.pop("POETRY_ACTIVE", None)
+        cls.test_env["HOME"] = str(pearl_home_root)
+        cls.test_env["TEST_PASSWORD"] = cls.password
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        # Best-effort: stop everything in both quickstart cwds before cleaning.
+        # Use the per-quickstart password so the cleanup's stop_service.sh
+        # doesn't hang on a password prompt.
+        qs_dirs = getattr(cls, "qs_dirs", ())
+        passwords = (
+            getattr(cls, "password", None),
+            getattr(cls, "qs2_password", None),
+        )
+        for qs, pw in zip(qs_dirs, passwords):
+            for cfg in QS_CONFIGS:
+                try:
+                    with _override_test_password(pw):
+                        ensure_service_stopped(cfg, str(qs), cls.logger)
+                except Exception as exc:  # pylint: disable=broad-except
+                    cls.logger.warning(f"teardown stop failed: {exc}")
+        if hasattr(cls, "work_root"):
+            cleanup_directory(cls.work_root.name, cls.logger)
+
+    # ------------------------------------------------------------------
+    # Helpers for the implicit step ordering
+    # ------------------------------------------------------------------
+    def setup_method(self) -> None:
+        """Skip downstream steps once any earlier step has failed.
+
+        Pytest-default behaviour would still run later steps after a failure,
+        producing misleading cascade errors (e.g. "Pearl home doesn't exist"
+        because step 02 never wrote it). Short-circuit instead.
+        """
+        if type(self)._failed:
+            pytest.skip("earlier step in the migration sequence failed; skipping")
+
+    def _step(self, fn) -> None:
+        """Run a step body, marking the class as failed if it raises."""
+        try:
+            fn()
+        except BaseException:
+            type(self)._failed = True
+            raise
+
+    # ------------------------------------------------------------------
+    # Setup phase: deploy 2 services in each quickstart, then stop them.
+    # ------------------------------------------------------------------
+    def test_01_deploy_two_services_per_quickstart(self) -> None:
+        def _body() -> None:
+            for qs in self.qs_dirs:
+                # qs1 uses the base password; qs2 uses a different one so
+                # the Mode B merge in test_03 has two distinct passwords
+                # to handle (quickstart-side != Pearl-side).
+                pw = self.password if qs is self.qs_dirs[0] else self.qs2_password
+                self.logger.info(
+                    f"=== Deploying services in {qs} (password={'qs1' if pw == self.password else 'qs2'}) ==="
+                )
+                for cfg in QS_CONFIGS:
+                    _spawn_run_service(qs, cfg, self.test_env, self.logger, password=pw)
+                    _spawn_stop_service(qs, cfg, self.test_env, self.logger, password=pw)
+
+            # Sanity check: each cwd should now have 2 sc-* dirs in its .operate.
+            for qs in self.qs_dirs:
+                services = _list_pearl_services(qs / OPERATE)
+                assert len(services) == 2, (
+                    f"Expected 2 services in {qs / OPERATE}, found {len(services)}: "
+                    f"{[p.name for p in services]}"
+                )
+
+        self._step(_body)
+
+    # ------------------------------------------------------------------
+    # Migration phase: qs1 (Mode A) then qs2 (Mode B).
+    # ------------------------------------------------------------------
+    def test_02_migrate_first_quickstart_mode_a(self) -> None:
+        def _body() -> None:
+            assert not self.pearl_home.exists(), \
+                "Pearl home should not exist before the first migration"
+
+            _spawn_migrate_to_pearl(
+                cwd=self.qs_dirs[0],
+                pearl_home=self.pearl_home,
+                password=self.password,
+                pearl_password=self.password,  # unused on Mode A
+                env=self.test_env,
+                logger=self.logger,
+            )
+
+            services = _list_pearl_services(self.pearl_home)
+            assert len(services) == 2, (
+                f"After Mode A, expected 2 services in {self.pearl_home / 'services'}, "
+                f"found {[p.name for p in services]}"
+            )
+            # Master wallet from qs1 must be present.
+            assert (self.pearl_home / "wallets" / "ethereum.json").exists()
+            assert (self.pearl_home / "wallets" / "ethereum.txt").exists()
+
+        self._step(_body)
+
+    def test_03_migrate_second_quickstart_mode_b(self) -> None:
+        def _body() -> None:
+            assert self.pearl_home.exists(), \
+                "Pearl home must exist before the Mode B migration"
+
+            # qs2 has its own master password; Pearl's wallet is qs1's
+            # (carried over by the Mode A copy in test_02), so its password
+            # is `self.password`. The migration script prompts for both.
+            _spawn_migrate_to_pearl(
+                cwd=self.qs_dirs[1],
+                pearl_home=self.pearl_home,
+                password=self.qs2_password,
+                pearl_password=self.password,
+                env=self.test_env,
+                logger=self.logger,
+            )
+
+            services = _list_pearl_services(self.pearl_home)
+            assert len(services) == 4, (
+                f"After Mode B merge, expected 4 services in {self.pearl_home / 'services'}, "
+                f"found {[p.name for p in services]}"
+            )
+
+            # Each service's referenced agent key must be present.
+            for svc_dir in services:
+                cfg = json.loads((svc_dir / "config.json").read_text())
+                for addr in cfg.get("agent_addresses", []):
+                    assert (self.pearl_home / "keys" / addr).exists(), (
+                        f"Missing key {addr} for service {svc_dir.name}"
+                    )
+
+        self._step(_body)
+
+    # ------------------------------------------------------------------
+    # Verification phase: each migrated service can be started by Pearl.
+    # ------------------------------------------------------------------
+    def test_04_all_services_can_start_from_pearl_home(self) -> None:
+        def _body() -> None:
+            operate = OperateApp(home=self.pearl_home)
+            operate.password = self.password
+            # Sanity: the wallet manager unlocks with the same TEST_PASSWORD,
+            # demonstrating the migrated wallet is usable.
+            assert operate.wallet_manager.is_password_valid(self.password), (
+                "Migrated master wallet rejected the test password"
+            )
+            # Loading the wallet shouldn't raise.
+            operate.wallet_manager.load(LedgerType.ETHEREUM)
+
+            manager = operate.service_manager()
+            services = _list_pearl_services(self.pearl_home)
+            assert len(services) == 4
+
+            # ---- Direct on-chain assertions of the migration's invariants ----
+            # Don't rely on "deploy succeeded" as a proxy: a wrong-owner state
+            # with sufficient remaining permissions could still pass that.
+            # Read NFT owner + Safe owner list directly per chain.
+            from operate.ledger.profiles import CONTRACTS
+            from operate.operate_types import Chain
+            from scripts.pearl_migration.status import (
+                safe_owners as _safe_owners,
+                service_nft_owner as _service_nft_owner,
+            )
+            pearl_safes = operate.wallet_manager.load(LedgerType.ETHEREUM).safes
+            for svc_dir in services:
+                cfg = json.loads((svc_dir / "config.json").read_text())
+                sid = cfg["service_config_id"]
+                svc_obj = manager.load(service_config_id=sid)
+                for chain_str, chain_config in svc_obj.chain_configs.items():
+                    chain_enum = Chain(chain_str)
+                    pearl_safe = pearl_safes[chain_enum]
+                    sftxb = manager.get_eth_safe_tx_builder(
+                        ledger_config=chain_config.ledger_config,
+                    )
+                    nft_owner = _service_nft_owner(
+                        ledger_api=sftxb.ledger_api,
+                        service_registry_address=CONTRACTS[chain_enum]["service_registry"],
+                        service_id=chain_config.chain_data.token,
+                    )
+                    assert nft_owner is not None and nft_owner.lower() == pearl_safe.lower(), (
+                        f"[{chain_str}] service NFT {chain_config.chain_data.token} "
+                        f"owner is {nft_owner}, expected Pearl Safe {pearl_safe}"
+                    )
+                    owners = _safe_owners(
+                        ledger_api=sftxb.ledger_api,
+                        safe=chain_config.chain_data.multisig,
+                    )
+                    owners_lower = {o.lower() for o in owners}
+                    assert pearl_safe.lower() in owners_lower, (
+                        f"[{chain_str}] service Safe {chain_config.chain_data.multisig} "
+                        f"owners {owners} should include Pearl Safe {pearl_safe}"
+                    )
+
+            # Build a service-name -> origin config path map by reading the
+            # QS_CONFIGS files. This avoids `test_run_service.get_service_config`'s
+            # substring matching (which only works on config-file paths, not
+            # human names like "Trader Agent").
+            name_to_qs_cfg: Dict[str, str] = {}
+            for qs_cfg_path in QS_CONFIGS:
+                qs_cfg_data = json.loads(Path(qs_cfg_path).read_text())
+                name_to_qs_cfg[qs_cfg_data["name"]] = qs_cfg_path
+
+            started: List[str] = []
+            for svc_dir in services:
+                cfg = json.loads((svc_dir / "config.json").read_text())
+                sid = cfg["service_config_id"]
+                self.logger.info(
+                    f"=== Re-deploying migrated service {sid} ({cfg['name']}) ==="
+                )
+
+                service = manager.load(service_config_id=sid)
+                chain = service.home_chain
+
+                # 1) On-chain re-deploy from Pearl's master Safe. After our
+                # Mode B migration the service is in PRE_REGISTRATION owned
+                # by the Pearl master Safe. This walks it back through
+                # ACTIVE_REGISTRATION -> FINISHED_REGISTRATION -> DEPLOYED,
+                # exercising the chain-side code Pearl will run when the
+                # user clicks "Run" on the migrated service.
+                self.logger.info(f"  on-chain deploy from Safe ({chain})")
+                manager.deploy_service_onchain_from_safe(service_config_id=sid)
+
+                # 2) Local docker deploy.
+                self.logger.info(f"  local docker deploy ({chain})")
+                manager.deploy_service_locally(
+                    service_config_id=sid, chain=chain, use_docker=True,
+                )
+                time.sleep(STARTUP_WAIT)
+
+                # Resolve back to the config path so check_docker_status can
+                # find the agent-specific container_name (it does substring
+                # matching on the path).
+                origin_cfg = name_to_qs_cfg.get(cfg["name"])
+                assert origin_cfg is not None, (
+                    f"Migrated service name {cfg['name']!r} doesn't map back to "
+                    f"any of QS_CONFIGS; cannot resolve container name."
+                )
+                assert check_docker_status(self.logger, origin_cfg), (
+                    f"Service {sid} failed to start under Pearl `.operate`"
+                )
+                started.append(sid)
+
+                # Stop again before the next iteration so concurrent
+                # containers don't compete for ports.
+                manager.stop_service_locally(service_config_id=sid, force=True)
+                time.sleep(CONTAINER_STOP_WAIT)
+
+            assert len(started) == 4, f"Only started {len(started)}/4 services"
+
+        self._step(_body)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__, "-s", "--log-cli-level=INFO"])

--- a/tests/test_migrate_to_pearl.py
+++ b/tests/test_migrate_to_pearl.py
@@ -88,7 +88,14 @@ MIGRATION_TIMEOUT = 1200  # 20 min — Mode B can include several Safe txs
 # ---------------------------------------------------------------------------
 
 def _copy_repo_to(dest: Path, logger: logging.Logger) -> None:
-    """Copy the repo into `dest`, excluding heavy/local-only paths."""
+    """Copy the repo into `dest`, excluding heavy/local-only paths.
+
+    `.venv` is symlinked rather than copied: a deep copy via shutil
+    dereferences interpreter symlinks and silently drops parts of the
+    site-packages tree, and a fresh `poetry install` in `dest` triggers
+    PEP 517 sdist rebuilds (halo, python-baseconv) that fail under
+    Poetry 2.4 + setuptools >= 80. Sharing the runner's venv avoids
+    both pitfalls."""
     shutil.copytree(
         ".", dest, dirs_exist_ok=True,
         ignore=shutil.ignore_patterns(
@@ -96,6 +103,12 @@ def _copy_repo_to(dest: Path, logger: logging.Logger) -> None:
             "*.pyc", "logs", "*.log", ".env", ".venv",
         ),
     )
+    src_venv = Path(".venv").resolve()
+    if src_venv.is_dir():
+        link = dest / ".venv"
+        if link.exists() or link.is_symlink():
+            link.unlink()
+        link.symlink_to(src_venv)
     logger.info(f"Copied repo to {dest}")
 
 

--- a/tests/test_migrate_to_pearl.py
+++ b/tests/test_migrate_to_pearl.py
@@ -496,6 +496,20 @@ class TestMigrateToPearlEndToEnd:
             # Don't rely on "deploy succeeded" as a proxy: a wrong-owner state
             # with sufficient remaining permissions could still pass that.
             # Read NFT owner + Safe owner list directly per chain.
+            # Two invariants per chain:
+            #   1) NFT owner == Pearl Safe — proves Pearl can re-register /
+            #      terminate / redeploy the service via ServiceRegistry.
+            #      This is the load-bearing migration contract.
+            #   2) Multisig owners are in one of two valid post-migration
+            #      states:
+            #        - Mode A (filesystem-only copy, no on-chain change):
+            #          owners == registered agent EOAs, the post-deploy
+            #          state inherited from the original quickstart.
+            #        - Mode B (terminated + swapped during migration):
+            #          owners == [Pearl Safe], because terminate swapped
+            #          agents -> master Safe and the migration then
+            #          swapped quickstart Safe -> Pearl Safe.
+            #      Anything else means the service is stuck mid-state.
             from operate.ledger.profiles import CONTRACTS
             from operate.operate_types import Chain
             from scripts.pearl_migration.status import (
@@ -527,9 +541,13 @@ class TestMigrateToPearlEndToEnd:
                         safe=chain_config.chain_data.multisig,
                     )
                     owners_lower = {o.lower() for o in owners}
-                    assert pearl_safe.lower() in owners_lower, (
+                    expected_agents = {a.lower() for a in svc_obj.agent_addresses}
+                    expected_pearl = {pearl_safe.lower()}
+                    assert owners_lower in (expected_agents, expected_pearl), (
                         f"[{chain_str}] service Safe {chain_config.chain_data.multisig} "
-                        f"owners {owners} should include Pearl Safe {pearl_safe}"
+                        f"owners {owners} match neither the registered agent "
+                        f"EOAs {sorted(expected_agents)} (Mode A) nor "
+                        f"[{pearl_safe}] (Mode B)"
                     )
 
             # Build a service-name -> origin config path map by reading the

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -605,9 +605,9 @@ def get_base_config(config_path: str = "") -> dict:
         r"Please input your password \(or press enter\)\:": base_config["TEST_PASSWORD"],
         r"Please confirm your password\:": base_config["TEST_PASSWORD"],
         r"Enter local user account password \[hidden input\]\:": base_config["TEST_PASSWORD"],
-        r"Enter your choice": base_config["STAKING_CHOICE"],
+        r"Enter your choice\s*\(\s*\d+\s*-\s*\d+\s*\)\s*:\s*$": base_config["STAKING_CHOICE"],
         r"Please input your backup owner \(leave empty to skip\)\:": base_config["BACKUP_WALLET"],
-        r"Press enter to continue": "\n",
+        r"Press enter to continue\.*\s*$": "\n",
         r"Please enter .*(?:\[hidden input\])?:\s*$": lambda output, logger: handle_env_var_prompt(output, logger, config_path)
     }
 

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -877,6 +877,22 @@ class TestFilesystemExtras:
         # Should be a no-op, no exceptions.
         filesystem.fix_root_ownership(store)
 
+    def test_fix_root_ownership_empty_services_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """services/ exists but contains no service dirs — chown loop is
+        skipped and subprocess.run is never called."""
+        (tmp_path / "services").mkdir()
+        called: list[Any] = []
+        monkeypatch.setattr(
+            filesystem.subprocess,
+            "run",
+            lambda *a, **k: called.append((a, k)),
+        )
+        store = detect.OperateStore(root=tmp_path)
+        filesystem.fix_root_ownership(store)
+        assert called == []
+
     def test_fix_root_ownership_runs_chown(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -1160,29 +1160,66 @@ class TestTransfer:
         assert sent["to"] == "0xreg"
         assert sent["txd"] == bytes.fromhex("deadbeef")
 
-    def test_swap_service_safe_owner_delegates(
+    def test_swap_service_safe_owner_dispatches_via_qs_master_safe(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """Swap MUST be sent as a Safe tx originated by the quickstart
+        master Safe (the qs Safe is the owner of the service multisig
+        after terminate); signing as the EOA against the service Safe
+        directly fails Gnosis signature validation (GS026) and the tx
+        silently reverts on-chain. Verify wiring: encoded swapOwner
+        calldata, send_safe_txs(safe=qs_master_safe, to=service_safe)."""
         from scripts.pearl_migration import transfer
 
+        # Stub autonomy.chain.base.registry_contracts.gnosis_safe.
+        autonomy_pkg = types.ModuleType("autonomy")
+        autonomy_chain = types.ModuleType("autonomy.chain")
+        autonomy_base = types.ModuleType("autonomy.chain.base")
+        class _FakeInstance:
+            def encode_abi(self, *, abi_element_identifier: str, args: list) -> str:
+                assert abi_element_identifier == "swapOwner"
+                assert args == ["0xprev", "0xqsafe", "0xpearl"]
+                return "0xdeadbeef"
+        class _FakeGnosisSafe:
+            @staticmethod
+            def get_instance(*, ledger_api: Any, contract_address: str) -> Any:
+                assert contract_address == "0xservice"
+                return _FakeInstance()
+        autonomy_base.registry_contracts = types.SimpleNamespace(  # type: ignore[attr-defined]
+            gnosis_safe=_FakeGnosisSafe(),
+        )
+        monkeypatch.setitem(sys.modules, "autonomy", autonomy_pkg)
+        monkeypatch.setitem(sys.modules, "autonomy.chain", autonomy_chain)
+        monkeypatch.setitem(sys.modules, "autonomy.chain.base", autonomy_base)
+
+        # Stub operate.utils.gnosis.{get_prev_owner, send_safe_txs}.
         captured: dict[str, Any] = {}
         operate_pkg = types.ModuleType("operate")
         operate_utils = types.ModuleType("operate.utils")
         operate_gnosis = types.ModuleType("operate.utils.gnosis")
-        def fake_swap(**kw: Any) -> None:
+        def fake_get_prev_owner(*, ledger_api: Any, safe: str, owner: str) -> str:
+            assert safe == "0xservice" and owner == "0xqsafe"
+            return "0xprev"
+        def fake_send(**kw: Any) -> str:
             captured.update(kw)
-        operate_gnosis.swap_owner = fake_swap  # type: ignore[attr-defined]
+            return "0xtx"
+        operate_gnosis.get_prev_owner = fake_get_prev_owner  # type: ignore[attr-defined]
+        operate_gnosis.send_safe_txs = fake_send  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "operate", operate_pkg)
         monkeypatch.setitem(sys.modules, "operate.utils", operate_utils)
         monkeypatch.setitem(sys.modules, "operate.utils.gnosis", operate_gnosis)
 
         transfer.swap_service_safe_owner(
             ledger_api="LA", crypto="CR",
-            service_safe="0xs", old_owner="0xo", new_owner="0xn",
+            service_safe="0xservice",
+            old_owner="0xqsafe", new_owner="0xpearl",
         )
         assert captured == {
-            "ledger_api": "LA", "crypto": "CR",
-            "safe": "0xs", "old_owner": "0xo", "new_owner": "0xn",
+            "txd": bytes.fromhex("deadbeef"),
+            "safe": "0xqsafe",
+            "ledger_api": "LA",
+            "crypto": "CR",
+            "to": "0xservice",
         }
 
 

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -1160,31 +1160,47 @@ class TestTransfer:
         assert sent["to"] == "0xreg"
         assert sent["txd"] == bytes.fromhex("deadbeef")
 
-    def test_swap_service_safe_owner_dispatches_via_qs_master_safe(
+    def test_swap_service_safe_owner_uses_approve_hash_then_exec_pattern(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Swap MUST be sent as a Safe tx originated by the quickstart
-        master Safe (the qs Safe is the owner of the service multisig
-        after terminate); signing as the EOA against the service Safe
-        directly fails Gnosis signature validation (GS026) and the tx
-        silently reverts on-chain. Verify wiring: encoded swapOwner
-        calldata, send_safe_txs(safe=qs_master_safe, to=service_safe)."""
+        """Swap MUST be the Safe-A-controlling-Safe-B pattern: qs master
+        Safe first calls service Safe.approveHash(inner_tx_hash), then
+        calls service Safe.execTransaction(...) with a packed
+        approved-hash signature. Calling swapOwner directly from the qs
+        master Safe (single send_safe_txs) fails because Gnosis
+        swapOwner requires `msg.sender == address(this)` (i.e. it MUST
+        go through execTransaction on the service Safe itself)."""
         from scripts.pearl_migration import transfer
 
-        # Stub autonomy.chain.base.registry_contracts.gnosis_safe.
+        # autonomy.chain.base.registry_contracts.gnosis_safe stub.
         autonomy_pkg = types.ModuleType("autonomy")
         autonomy_chain = types.ModuleType("autonomy.chain")
         autonomy_base = types.ModuleType("autonomy.chain.base")
+        encoded: list[tuple[str, list]] = []
         class _FakeInstance:
             def encode_abi(self, *, abi_element_identifier: str, args: list) -> str:
-                assert abi_element_identifier == "swapOwner"
-                assert args == ["0xprev", "0xqsafe", "0xpearl"]
-                return "0xdeadbeef"
+                encoded.append((abi_element_identifier, args))
+                # Return distinguishable hex per element so we can verify
+                # which calldata went to which send_safe_txs call.
+                return {
+                    "swapOwner": "0x1100",
+                    "approveHash": "0x2200",
+                    "execTransaction": "0x3300",
+                }[abi_element_identifier]
         class _FakeGnosisSafe:
             @staticmethod
             def get_instance(*, ledger_api: Any, contract_address: str) -> Any:
                 assert contract_address == "0xservice"
                 return _FakeInstance()
+            @staticmethod
+            def get_raw_safe_transaction_hash(**kw: Any) -> dict:
+                # Reflect args back so the test asserts the inner-tx-hash
+                # request is for a self-call on the service Safe with
+                # the swapOwner calldata.
+                assert kw["contract_address"] == "0xservice"
+                assert kw["to_address"] == "0xservice"
+                assert kw["data"] == bytes.fromhex("1100")
+                return {"tx_hash": "0xabcdef"}
         autonomy_base.registry_contracts = types.SimpleNamespace(  # type: ignore[attr-defined]
             gnosis_safe=_FakeGnosisSafe(),
         )
@@ -1192,20 +1208,29 @@ class TestTransfer:
         monkeypatch.setitem(sys.modules, "autonomy.chain", autonomy_chain)
         monkeypatch.setitem(sys.modules, "autonomy.chain.base", autonomy_base)
 
-        # Stub operate.utils.gnosis.{get_prev_owner, send_safe_txs}.
-        captured: dict[str, Any] = {}
+        # operate stubs.
+        sends: list[dict[str, Any]] = []
         operate_pkg = types.ModuleType("operate")
+        operate_services = types.ModuleType("operate.services")
+        operate_protocol = types.ModuleType("operate.services.protocol")
         operate_utils = types.ModuleType("operate.utils")
         operate_gnosis = types.ModuleType("operate.utils.gnosis")
-        def fake_get_prev_owner(*, ledger_api: Any, safe: str, owner: str) -> str:
-            assert safe == "0xservice" and owner == "0xqsafe"
-            return "0xprev"
-        def fake_send(**kw: Any) -> str:
-            captured.update(kw)
-            return "0xtx"
-        operate_gnosis.get_prev_owner = fake_get_prev_owner  # type: ignore[attr-defined]
-        operate_gnosis.send_safe_txs = fake_send  # type: ignore[attr-defined]
+        operate_protocol.get_packed_signature_for_approved_hash = (  # type: ignore[attr-defined]
+            lambda *, owners: b"PACKED_SIG_FOR_" + owners[0].encode()
+        )
+        class _SafeOperation:
+            class CALL:
+                value = 0
+        operate_gnosis.SafeOperation = _SafeOperation  # type: ignore[attr-defined]
+        operate_gnosis.get_prev_owner = (  # type: ignore[attr-defined]
+            lambda *, ledger_api, safe, owner: "0xprev"
+        )
+        operate_gnosis.send_safe_txs = (  # type: ignore[attr-defined]
+            lambda **kw: sends.append(kw) or "0xtx"
+        )
         monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+        monkeypatch.setitem(sys.modules, "operate.services", operate_services)
+        monkeypatch.setitem(sys.modules, "operate.services.protocol", operate_protocol)
         monkeypatch.setitem(sys.modules, "operate.utils", operate_utils)
         monkeypatch.setitem(sys.modules, "operate.utils.gnosis", operate_gnosis)
 
@@ -1214,13 +1239,29 @@ class TestTransfer:
             service_safe="0xservice",
             old_owner="0xqsafe", new_owner="0xpearl",
         )
-        assert captured == {
-            "txd": bytes.fromhex("deadbeef"),
-            "safe": "0xqsafe",
-            "ledger_api": "LA",
-            "crypto": "CR",
-            "to": "0xservice",
-        }
+
+        # Three encode_abi calls: swapOwner (for the inner-hash and exec
+        # data fields), approveHash, execTransaction.
+        assert [name for name, _ in encoded] == [
+            "swapOwner", "approveHash", "execTransaction",
+        ]
+        assert encoded[0][1] == ["0xprev", "0xqsafe", "0xpearl"]
+        assert encoded[1][1] == ["0xabcdef"]  # approveHash(inner_tx_hash)
+        # execTransaction args: to=service, value=0, data=swapOwner bytes,
+        # operation=0, safeTxGas=0, baseGas=0, gasPrice=0, gasToken=zero,
+        # refundReceiver=zero, signatures=packed(qs_master_safe).
+        exec_args = encoded[2][1]
+        assert exec_args[0] == "0xservice"
+        assert exec_args[2] == bytes.fromhex("1100")
+        assert exec_args[-1] == b"PACKED_SIG_FOR_0xqsafe"
+
+        # Two send_safe_txs calls — both originated by qs master Safe and
+        # targeting service Safe.
+        assert len(sends) == 2
+        assert sends[0]["safe"] == "0xqsafe" and sends[0]["to"] == "0xservice"
+        assert sends[0]["txd"] == bytes.fromhex("2200")  # approveHash
+        assert sends[1]["safe"] == "0xqsafe" and sends[1]["to"] == "0xservice"
+        assert sends[1]["txd"] == bytes.fromhex("3300")  # execTransaction
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -300,7 +300,6 @@ class TestMergeService:
         # Fresh copy in place.
         assert (dest.services_dir / "sc-aaa" / "config.json").exists()
 
-
 # ---------------------------------------------------------------------------
 # prompts.py
 # ---------------------------------------------------------------------------
@@ -856,6 +855,130 @@ class TestDetectExtras:
         monkeypatch.setattr(Path, "resolve", boom)
         with pytest.raises(ValueError, match="Cannot resolve store root"):
             detect.OperateStore(root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# wallet.py — quickstart-side password alignment
+# ---------------------------------------------------------------------------
+
+class TestAlignQuickstartPassword:
+    def test_no_op_when_passwords_match(self) -> None:
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        update_calls: list[str] = []
+        qs_app = types.SimpleNamespace(
+            password="same",
+            keys_manager=types.SimpleNamespace(path=Path("/tmp/nope")),
+        )
+        qs_wallet = types.SimpleNamespace(
+            update_password=lambda new: update_calls.append(new),
+        )
+        wallet_mod.align_quickstart_password(
+            qs_app=qs_app, qs_wallet=qs_wallet, new_password="same",
+        )
+        assert update_calls == []
+        assert qs_app.password == "same"
+
+    def test_reencrypts_master_and_agent_keys(self, tmp_path: Path) -> None:
+        from eth_account import Account
+        from operate.keys import Key
+        from operate.operate_types import LedgerType
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        # Two agent keyfiles encrypted with the OLD password.
+        old_pw, new_pw = "old-pw", "new-pw"
+        keys_dir = tmp_path / "keys"
+        keys_dir.mkdir()
+        agent_pks: dict[str, bytes] = {}
+        for i in (1, 2):
+            raw = bytes([i]) * 32
+            addr = Account.from_key(raw).address
+            agent_pks[addr] = raw
+            keyfile = Account.encrypt(raw, old_pw)
+            key = Key(  # type: ignore[call-arg]
+                ledger=LedgerType.ETHEREUM,
+                address=addr,
+                private_key=json.dumps(keyfile),
+            )
+            (keys_dir / addr).write_text(json.dumps(key.json), encoding="utf-8")
+        # A `.bak` sibling — must be skipped by the walker.
+        (keys_dir / "stale.bak").write_text("{}", encoding="utf-8")
+
+        master_calls: list[str] = []
+        qs_wallet = types.SimpleNamespace(
+            update_password=lambda new: master_calls.append(new),
+        )
+        keys_manager = types.SimpleNamespace(path=keys_dir, password=old_pw)
+        qs_app = types.SimpleNamespace(
+            password=old_pw, keys_manager=keys_manager,
+        )
+
+        wallet_mod.align_quickstart_password(
+            qs_app=qs_app, qs_wallet=qs_wallet, new_password=new_pw,
+        )
+
+        # Master keyfile re-encrypt was delegated to operate's update_password.
+        assert master_calls == [new_pw]
+        # qs_app and the keys manager now report the new password.
+        assert qs_app.password == new_pw
+        assert keys_manager.password == new_pw
+        # Each agent keyfile decrypts under the new password to the
+        # original raw private key, and rejects the old password.
+        for addr, raw in agent_pks.items():
+            blob = json.loads((keys_dir / addr).read_text(encoding="utf-8"))
+            inner = json.loads(blob["private_key"])
+            assert bytes(Account.decrypt(inner, new_pw)) == raw
+            with pytest.raises(Exception):
+                Account.decrypt(inner, old_pw)
+
+    def test_reencrypt_failure_is_propagated_and_warned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Failure inside _reencrypt_agent_key MUST propagate so the caller
+        aborts the migration rather than half-converting the keys dir."""
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        keys_dir = tmp_path / "keys"
+        keys_dir.mkdir()
+        (keys_dir / "0xagent").write_text("{}", encoding="utf-8")
+
+        warn_calls: list[str] = []
+        monkeypatch.setattr(wallet_mod, "warn", lambda msg: warn_calls.append(msg))
+
+        def boom(**kwargs: Any) -> None:
+            raise RuntimeError("disk full")
+        monkeypatch.setattr(wallet_mod, "_reencrypt_agent_key", boom)
+
+        qs_wallet = types.SimpleNamespace(update_password=lambda new: None)
+        qs_app = types.SimpleNamespace(
+            password="old",
+            keys_manager=types.SimpleNamespace(path=keys_dir, password="old"),
+        )
+        with pytest.raises(RuntimeError, match="disk full"):
+            wallet_mod.align_quickstart_password(
+                qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
+            )
+        assert any("failed to re-encrypt" in msg for msg in warn_calls)
+
+    def test_skips_walk_when_keys_dir_missing(self, tmp_path: Path) -> None:
+        """A quickstart with no agent keys yet (services pre-deploy) must
+        still re-encrypt the master keyfile and update qs_app.password."""
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        master_calls: list[str] = []
+        qs_wallet = types.SimpleNamespace(
+            update_password=lambda new: master_calls.append(new),
+        )
+        keys_manager = types.SimpleNamespace(
+            path=tmp_path / "absent_keys", password="old",
+        )
+        qs_app = types.SimpleNamespace(password="old", keys_manager=keys_manager)
+        wallet_mod.align_quickstart_password(
+            qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
+        )
+        assert master_calls == ["new"]
+        assert qs_app.password == "new"
+        assert keys_manager.password == "new"
 
 
 # ---------------------------------------------------------------------------
@@ -3519,6 +3642,80 @@ class TestDrainMaster:
 
 
 class TestRunModeB:
+    def test_password_align_runs_when_passwords_differ(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """qs_app.password != pearl_app.password -> user is asked to confirm
+        and align_quickstart_password is invoked with Pearl's password."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"; qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"; pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        passwords = iter(["qs-pw", "pearl-pw"])
+        monkeypatch.setattr(
+            m, "_load_wallet",
+            lambda store, label: (
+                types.SimpleNamespace(password=next(passwords)), "WALLET",
+            ),
+        )
+        align_calls: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            m, "align_quickstart_password",
+            lambda **kw: align_calls.append(kw),
+        )
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        monkeypatch.setattr(
+            m, "merge_service",
+            lambda service, src, dest: types.SimpleNamespace(),
+        )
+        monkeypatch.setattr(m, "_drain_master", lambda **kw: [])
+        monkeypatch.setattr(m, "rename_source_for_rollback", lambda src: src.root)
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: True)
+
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+
+        assert len(align_calls) == 1
+        assert align_calls[0]["new_password"] == "pearl-pw"
+        out = capsys.readouterr().out
+        assert "ALIGNING QUICKSTART PASSWORD" in out
+
+    def test_password_align_aborts_on_user_decline(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"; qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"; pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        passwords = iter(["qs-pw", "pearl-pw"])
+        monkeypatch.setattr(
+            m, "_load_wallet",
+            lambda store, label: (
+                types.SimpleNamespace(password=next(passwords)), "WALLET",
+            ),
+        )
+        align_called = {"n": 0}
+        monkeypatch.setattr(
+            m, "align_quickstart_password",
+            lambda **kw: align_called.update(n=align_called["n"] + 1),
+        )
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: False)
+
+        with pytest.raises(SystemExit):
+            m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        assert align_called["n"] == 0
+
     def test_dry_run_short_circuits(
         self, orch: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
@@ -3547,7 +3744,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -3584,7 +3781,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         def boom(**kw: Any) -> None:
             raise m._Unmigratable(
@@ -3626,7 +3823,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         def boom_copy(service: Any, src: Any, dest: Any) -> None:
@@ -3665,7 +3862,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         def boom_copy(service: Any, src: Any, dest: Any) -> None:
@@ -3692,7 +3889,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -3741,7 +3938,7 @@ class TestRunModeB:
             chain_configs={"gnosis": chain_config},
         )
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -3790,7 +3987,7 @@ class TestRunModeB:
                               chain_configs={"gnosis": cc_b})
 
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -3849,7 +4046,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: ("APP", "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -518,7 +518,7 @@ class TestStatusOSChecks:
         class FakeStat:
             st_uid = 0
 
-        monkeypatch.setattr(Path, "stat", lambda self: FakeStat())
+        monkeypatch.setattr(Path, "stat", lambda self, **kwargs: FakeStat())
         assert status.is_root_owned(f) is True
 
     def test_is_root_owned_propagates_oserror(
@@ -529,8 +529,8 @@ class TestStatusOSChecks:
         the subsequent copytree would corrupt the destination."""
         f = tmp_path / "x"
         f.write_text("hi")
-        monkeypatch.setattr(Path, "exists", lambda self: True)
-        def boom(self: Path) -> None:
+        monkeypatch.setattr(Path, "exists", lambda self, **kwargs: True)
+        def boom(self: Path, **kwargs: Any) -> None:
             raise OSError("permission denied")
         monkeypatch.setattr(Path, "stat", boom)
         with pytest.raises(OSError, match="permission denied"):
@@ -560,7 +560,7 @@ class TestStatusOSChecks:
             st_uid = 0
             st_mode = _statmod.S_IFREG | 0o644
 
-        def fake_stat(self: Path) -> Any:
+        def fake_stat(self: Path, **kwargs: Any) -> Any:
             return FakeStatChild() if self == child else FakeStatRoot()
         monkeypatch.setattr(Path, "stat", fake_stat)
         assert status.any_root_owned_under(tmp_path) is True
@@ -589,10 +589,10 @@ class TestStatusOSChecks:
 
         original_stat = Path.stat
 
-        def stat_raises_for_child(self: Path) -> Any:
+        def stat_raises_for_child(self: Path, **kwargs: Any) -> Any:
             if self.name == "x":
                 raise OSError("permission")
-            return original_stat(self)
+            return original_stat(self, **kwargs)
         monkeypatch.setattr(Path, "stat", stat_raises_for_child)
         with pytest.raises(OSError, match="permission"):
             status.any_root_owned_under(tmp_path)

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -887,8 +887,16 @@ class TestAlignQuickstartPassword:
 
         # Two agent keyfiles encrypted with the OLD password.
         old_pw, new_pw = "old-pw", "new-pw"
-        keys_dir = tmp_path / "keys"
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        keys_dir = operate_root / "keys"
+        wallets_dir.mkdir(parents=True)
         keys_dir.mkdir()
+        # Master keyfile placeholder — content doesn't matter; the test
+        # stubs `qs_wallet.update_password`, so the snapshot just needs a
+        # readable directory tree to copy.
+        (wallets_dir / "ethereum.txt").write_text("master", encoding="utf-8")
+
         agent_pks: dict[str, bytes] = {}
         for i in (1, 2):
             raw = bytes([i]) * 32
@@ -901,11 +909,13 @@ class TestAlignQuickstartPassword:
                 private_key=json.dumps(keyfile),
             )
             (keys_dir / addr).write_text(json.dumps(key.json), encoding="utf-8")
-        # A `.bak` sibling — must be skipped by the walker.
+        # A `.bak` sibling and a stale `.tmp` — both must be skipped.
         (keys_dir / "stale.bak").write_text("{}", encoding="utf-8")
+        (keys_dir / "stale.tmp").write_text("{}", encoding="utf-8")
 
         master_calls: list[str] = []
         qs_wallet = types.SimpleNamespace(
+            path=wallets_dir,
             update_password=lambda new: master_calls.append(new),
         )
         keys_manager = types.SimpleNamespace(path=keys_dir, password=old_pw)
@@ -930,6 +940,18 @@ class TestAlignQuickstartPassword:
             assert bytes(Account.decrypt(inner, new_pw)) == raw
             with pytest.raises(Exception):
                 Account.decrypt(inner, old_pw)
+        # Snapshot directory exists alongside wallets/ + keys/ for recovery.
+        snap_dirs = list(operate_root.glob(".pre-align.*"))
+        assert len(snap_dirs) == 1
+        assert (snap_dirs[0] / "wallets" / "ethereum.txt").exists()
+        # The snapshot's agent keyfiles still encrypt under the OLD password
+        # (proves they were captured before mutation, not after).
+        for addr, raw in agent_pks.items():
+            snap_blob = json.loads(
+                (snap_dirs[0] / "keys" / addr).read_text(encoding="utf-8"),
+            )
+            snap_inner = json.loads(snap_blob["private_key"])
+            assert bytes(Account.decrypt(snap_inner, old_pw)) == raw
 
     def test_reencrypt_failure_is_propagated_and_warned(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
@@ -938,7 +960,10 @@ class TestAlignQuickstartPassword:
         aborts the migration rather than half-converting the keys dir."""
         from scripts.pearl_migration import wallet as wallet_mod
 
-        keys_dir = tmp_path / "keys"
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        keys_dir = operate_root / "keys"
+        wallets_dir.mkdir(parents=True)
         keys_dir.mkdir()
         (keys_dir / "0xagent").write_text("{}", encoding="utf-8")
 
@@ -949,7 +974,9 @@ class TestAlignQuickstartPassword:
             raise RuntimeError("disk full")
         monkeypatch.setattr(wallet_mod, "_reencrypt_agent_key", boom)
 
-        qs_wallet = types.SimpleNamespace(update_password=lambda new: None)
+        qs_wallet = types.SimpleNamespace(
+            path=wallets_dir, update_password=lambda new: None,
+        )
         qs_app = types.SimpleNamespace(
             password="old",
             keys_manager=types.SimpleNamespace(path=keys_dir, password="old"),
@@ -958,19 +985,103 @@ class TestAlignQuickstartPassword:
             wallet_mod.align_quickstart_password(
                 qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
             )
+        # User is told the recovery path — must include the snapshot dir.
         assert any("failed to re-encrypt" in msg for msg in warn_calls)
+        assert any(".pre-align." in msg for msg in warn_calls)
+
+    def test_snapshot_preserves_originals_after_partial_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The whole point of the snapshot is recovery. After a mid-loop
+        failure (key 1 already mutated, key 2 raised), the snapshot
+        copies of BOTH keys must still decrypt under the OLD password —
+        otherwise the user's recovery `mv` would restore corrupted state."""
+        from eth_account import Account
+        from operate.keys import Key
+        from operate.operate_types import LedgerType
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        old_pw, new_pw = "old-pw", "new-pw"
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        keys_dir = operate_root / "keys"
+        wallets_dir.mkdir(parents=True)
+        keys_dir.mkdir()
+        (wallets_dir / "ethereum.txt").write_text("master", encoding="utf-8")
+
+        agent_pks: dict[str, bytes] = {}
+        for i in (1, 2):
+            raw = bytes([i]) * 32
+            addr = Account.from_key(raw).address
+            agent_pks[addr] = raw
+            keyfile = Account.encrypt(raw, old_pw)
+            key = Key(  # type: ignore[call-arg]
+                ledger=LedgerType.ETHEREUM,
+                address=addr,
+                private_key=json.dumps(keyfile),
+            )
+            (keys_dir / addr).write_text(json.dumps(key.json), encoding="utf-8")
+
+        # Stub _reencrypt_agent_key to mutate the FIRST key (re-encrypt
+        # under new_pw) and raise on the SECOND. Mirrors the real partial-
+        # failure shape: walk gets through some files before erroring.
+        seen: list[Path] = []
+        original = wallet_mod._reencrypt_agent_key
+        def partial(*, key_path: Path, old_password: str, new_password: str) -> None:
+            seen.append(key_path)
+            if len(seen) == 1:
+                original(
+                    key_path=key_path,
+                    old_password=old_password,
+                    new_password=new_password,
+                )
+                return
+            raise RuntimeError("io error mid-walk")
+        monkeypatch.setattr(wallet_mod, "_reencrypt_agent_key", partial)
+
+        qs_wallet = types.SimpleNamespace(
+            path=wallets_dir, update_password=lambda new: None,
+        )
+        qs_app = types.SimpleNamespace(
+            password=old_pw,
+            keys_manager=types.SimpleNamespace(path=keys_dir, password=old_pw),
+        )
+        with pytest.raises(RuntimeError, match="io error mid-walk"):
+            wallet_mod.align_quickstart_password(
+                qs_app=qs_app, qs_wallet=qs_wallet, new_password=new_pw,
+            )
+
+        # Snapshot must exist and must contain ORIGINAL (old-pw) copies of
+        # BOTH keys — the first key in the live tree is now new-pw'd, but
+        # the snapshot is the recovery surface and MUST be unaffected.
+        snap_dirs = list(operate_root.glob(".pre-align.*"))
+        assert len(snap_dirs) == 1
+        for addr, raw in agent_pks.items():
+            snap_blob = json.loads(
+                (snap_dirs[0] / "keys" / addr).read_text(encoding="utf-8"),
+            )
+            snap_inner = json.loads(snap_blob["private_key"])
+            assert bytes(Account.decrypt(snap_inner, old_pw)) == raw, (
+                f"snapshot copy of {addr} no longer decrypts under old "
+                "password — recovery would restore corrupted state"
+            )
 
     def test_skips_walk_when_keys_dir_missing(self, tmp_path: Path) -> None:
         """A quickstart with no agent keys yet (services pre-deploy) must
         still re-encrypt the master keyfile and update qs_app.password."""
         from scripts.pearl_migration import wallet as wallet_mod
 
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        wallets_dir.mkdir(parents=True)
+
         master_calls: list[str] = []
         qs_wallet = types.SimpleNamespace(
+            path=wallets_dir,
             update_password=lambda new: master_calls.append(new),
         )
         keys_manager = types.SimpleNamespace(
-            path=tmp_path / "absent_keys", password="old",
+            path=operate_root / "absent_keys", password="old",
         )
         qs_app = types.SimpleNamespace(password="old", keys_manager=keys_manager)
         wallet_mod.align_quickstart_password(
@@ -979,6 +1090,75 @@ class TestAlignQuickstartPassword:
         assert master_calls == ["new"]
         assert qs_app.password == "new"
         assert keys_manager.password == "new"
+
+    def test_skips_non_file_entries_in_keys_dir(self, tmp_path: Path) -> None:
+        """A subdirectory under keys/ (legacy artifact) must be skipped, not
+        passed to _reencrypt_agent_key."""
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        keys_dir = operate_root / "keys"
+        wallets_dir.mkdir(parents=True)
+        keys_dir.mkdir()
+        (keys_dir / "subdir").mkdir()  # not-a-file entry
+
+        qs_wallet = types.SimpleNamespace(
+            path=wallets_dir, update_password=lambda new: None,
+        )
+        qs_app = types.SimpleNamespace(
+            password="old",
+            keys_manager=types.SimpleNamespace(path=keys_dir, password="old"),
+        )
+        # Should not raise — subdir gets skipped silently.
+        wallet_mod.align_quickstart_password(
+            qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
+        )
+        assert qs_app.password == "new"
+
+    def test_old_password_captured_before_update_password(
+        self, tmp_path: Path,
+    ) -> None:
+        """qs_wallet.update_password may mutate qs_app.password as a side
+        effect (the wallet shares state with the manager). The function
+        MUST capture old_password before the rotate or every agent-key
+        decrypt fails silently."""
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        keys_dir = operate_root / "keys"
+        wallets_dir.mkdir(parents=True)
+        keys_dir.mkdir()
+
+        # update_password mutates qs_app.password (mirroring real operate
+        # behaviour where the wallet manager propagates the new password).
+        qs_app: Any = types.SimpleNamespace(
+            password="real-old",
+            keys_manager=types.SimpleNamespace(path=keys_dir, password="real-old"),
+        )
+        def mutate_password(new: str) -> None:
+            qs_app.password = new
+        qs_wallet = types.SimpleNamespace(
+            path=wallets_dir, update_password=mutate_password,
+        )
+
+        captured_old: list[str] = []
+        original_reencrypt = wallet_mod._reencrypt_agent_key
+        def capture(*, key_path: Any, old_password: str, new_password: str) -> None:
+            captured_old.append(old_password)
+        wallet_mod._reencrypt_agent_key = capture
+        try:
+            (keys_dir / "0xagent").write_text("{}", encoding="utf-8")
+            wallet_mod.align_quickstart_password(
+                qs_app=qs_app, qs_wallet=qs_wallet, new_password="real-new",
+            )
+        finally:
+            wallet_mod._reencrypt_agent_key = original_reencrypt
+        assert captured_old == ["real-old"], (
+            "old_password must be captured BEFORE update_password rotates it; "
+            f"got {captured_old}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1046,6 +1226,46 @@ class TestFilesystemExtras:
         # Must raise — caller would otherwise corrupt the destination.
         with pytest.raises(RuntimeError, match="could not chown"):
             filesystem.fix_root_ownership(store)
+
+    def test_fix_root_ownership_partial_failure_lists_audit_trail(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When chown succeeds on the first dir then fails on the second,
+        the raised message MUST list the successful one under 'Already
+        mutated' and name the failing one as the partially-mutated dir —
+        that audit trail is the user's only recovery surface for an
+        irreversible operation."""
+        services_dir = tmp_path / "services"
+        services_dir.mkdir()
+        (services_dir / "sc-aaa").mkdir()
+        (services_dir / "sc-bbb").mkdir()
+
+        # Order in which `services_dir.iterdir()` yields entries is not
+        # guaranteed — make the LAST chown call fail and capture the
+        # iteration order so the test reasons about it directly.
+        seen: list[str] = []
+        def fake_run(cmd: list[str], **kw: Any) -> Any:
+            target = cmd[-1]
+            seen.append(target)
+            if len(seen) == 2:  # second dir, whichever it is
+                raise subprocess.CalledProcessError(1, cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+        monkeypatch.setattr(filesystem.subprocess, "run", fake_run)
+
+        store = detect.OperateStore(root=tmp_path.resolve())
+        with pytest.raises(RuntimeError) as excinfo:
+            filesystem.fix_root_ownership(store)
+        msg = str(excinfo.value)
+        first_chowned, failing = seen
+        # The first dir was successfully chowned — must appear under
+        # "Already mutated".
+        assert "Already mutated:" in msg
+        assert first_chowned in msg
+        # The failing dir must be named as the partially-mutated one.
+        assert failing in msg
+        assert "indeterminate" in msg
+        # Both chown attempts ran (no early-exit before the failure).
+        assert len(seen) == 2
 
     def test_fix_root_ownership_refuses_outside_store(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1235,6 +1455,113 @@ class TestStop:
 # transfer.py
 # ---------------------------------------------------------------------------
 
+class TestPostConditionRetry:
+    """`_read_with_retry` and `PostConditionUnknown` make the post-tx
+    verification reads tolerant of transient RPC errors. The on-chain
+    side has already mined; an RPC hiccup must not be reported as
+    'transfer failed' (which would push the user into a re-run that
+    double-submits or hits a stale-prev-owner revert)."""
+
+    def test_returns_value_on_first_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import transfer
+        monkeypatch.setattr(transfer.time, "sleep", lambda *a, **k: None)
+        result = transfer._read_with_retry(lambda: "ok", tx_hash="0xtx")
+        assert result == "ok"
+
+    def test_retries_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import transfer
+        monkeypatch.setattr(transfer.time, "sleep", lambda *a, **k: None)
+        # Network-shaped failures (ConnectionError, TimeoutError) are
+        # retried; programming bugs are NOT — see the test below.
+        attempts = iter([
+            ConnectionError("rpc 502"), TimeoutError("rpc slow"), "good",
+        ])
+        def step() -> str:
+            v = next(attempts)
+            if isinstance(v, Exception):
+                raise v
+            return v
+        result = transfer._read_with_retry(step, tx_hash="0xtx", attempts=3)
+        assert result == "good"
+
+    def test_propagates_programming_bugs_without_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A regression in the lambda (TypeError, AttributeError, ...) is
+        a code defect, not a transient RPC issue. It MUST propagate
+        immediately so the user sees a real traceback rather than the
+        misleading 'verify on a block explorer' framing."""
+        from scripts.pearl_migration import transfer
+        sleeps: list[float] = []
+        monkeypatch.setattr(
+            transfer.time, "sleep", lambda s: sleeps.append(s),
+        )
+        calls = {"n": 0}
+        def buggy() -> str:
+            calls["n"] += 1
+            raise TypeError("regression: ownerOf signature changed")
+        with pytest.raises(TypeError, match="regression"):
+            transfer._read_with_retry(buggy, tx_hash="0xtx", attempts=3)
+        assert calls["n"] == 1, "must NOT retry programming bugs"
+        assert sleeps == [], "must NOT sleep before propagating programming bugs"
+
+    def test_attempts_must_be_at_least_one(self) -> None:
+        from scripts.pearl_migration import transfer
+        with pytest.raises(ValueError, match="attempts must be >= 1"):
+            transfer._read_with_retry(lambda: "x", tx_hash="0xtx", attempts=0)
+
+    def test_rpc_exception_types_tuple_covers_stdlib_and_optional_libs(
+        self,
+    ) -> None:
+        """The cached `_RPC_EXCEPTION_TYPES` tuple must include the
+        stdlib network-error bases AND the third-party RPC error roots
+        (web3 / requests). A regression that drops `Web3Exception` would
+        let a `ContractLogicError` from `ownerOf` escape the retry net
+        and surface as a non-`PostConditionUnknown` failure — the
+        migration would abort on a transient revert that retry might
+        have ridden through."""
+        import requests.exceptions
+        import web3.exceptions
+        from scripts.pearl_migration import transfer
+        excs = transfer._RPC_EXCEPTION_TYPES
+        # Stdlib bases — always must be present.
+        assert ConnectionError in excs
+        assert TimeoutError in excs
+        assert OSError in excs
+        # Python 3.10's `asyncio.TimeoutError` is a distinct subclass of
+        # Exception (not the builtin alias as in 3.11+) and the project
+        # supports 3.10 — must be in the tuple regardless of runtime.
+        import asyncio
+        assert asyncio.TimeoutError in excs
+        # Third-party RPC roots — load-bearing for retry semantics.
+        assert web3.exceptions.Web3Exception in excs
+        assert requests.exceptions.RequestException in excs
+
+    def test_raises_post_condition_unknown_after_exhaustion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Distinct exception type so callers can tell 'inner reverted'
+        (RuntimeError) apart from 'verification read RPC dead'
+        (PostConditionUnknown). Re-running blindly in the latter case
+        would fail because the on-chain side already mined."""
+        from scripts.pearl_migration import transfer
+        monkeypatch.setattr(transfer.time, "sleep", lambda *a, **k: None)
+        def always_fail() -> str:
+            raise ConnectionError("rpc 503")
+        with pytest.raises(transfer.PostConditionUnknown) as excinfo:
+            transfer._read_with_retry(
+                always_fail, tx_hash="0xMINED", attempts=3,
+            )
+        msg = str(excinfo.value)
+        assert "0xMINED" in msg
+        assert "DO NOT re-run" in msg
+        assert isinstance(excinfo.value.last_exc, ConnectionError)
+
+
 class TestTransfer:
     def test_transfer_service_nft_encodes_and_dispatches(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1242,10 +1569,21 @@ class TestTransfer:
         from scripts.pearl_migration import transfer
 
         encoded: dict[str, Any] = {}
+        # Stub `instance.functions.ownerOf(tid).call()` to return the Pearl
+        # Safe — this is the post-condition the function reads to confirm
+        # the transfer landed on-chain.
+        owner_of_calls: list[int] = []
+        class _OwnerOfCallable:
+            def __init__(self, token_id: int) -> None:
+                owner_of_calls.append(token_id)
+            def call(self) -> str:
+                return "0xpl"
+        functions = types.SimpleNamespace(ownerOf=_OwnerOfCallable)
         instance = types.SimpleNamespace(
             encode_abi=lambda abi_element_identifier, args: (
                 encoded.update(name=abi_element_identifier, args=args) or "0xdeadbeef"
             ),
+            functions=functions,
         )
         registry = types.SimpleNamespace(
             service_registry=types.SimpleNamespace(
@@ -1282,6 +1620,45 @@ class TestTransfer:
         assert sent["safe"] == "0xqs"
         assert sent["to"] == "0xreg"
         assert sent["txd"] == bytes.fromhex("deadbeef")
+        # Post-condition was actually checked.
+        assert owner_of_calls == [99]
+
+    def test_transfer_service_nft_raises_when_owner_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Inner-call revert leaves owner == qs Safe; transfer must raise
+        instead of returning a misleading 'success' tx hash."""
+        from scripts.pearl_migration import transfer
+
+        class _OwnerOfCallable:
+            def __init__(self, token_id: int) -> None: pass
+            def call(self) -> str: return "0xqs"  # unchanged: inner call reverted
+        instance = types.SimpleNamespace(
+            encode_abi=lambda abi_element_identifier, args: "0xdeadbeef",
+            functions=types.SimpleNamespace(ownerOf=_OwnerOfCallable),
+        )
+        registry = types.SimpleNamespace(
+            service_registry=types.SimpleNamespace(get_instance=lambda **kw: instance),
+        )
+        _install_fake_autonomy(monkeypatch, registry)
+
+        operate_pkg = types.ModuleType("operate")
+        operate_utils = types.ModuleType("operate.utils")
+        operate_gnosis = types.ModuleType("operate.utils.gnosis")
+        operate_gnosis.send_safe_txs = (  # type: ignore[attr-defined]
+            lambda **kw: "0xtxhash"
+        )
+        monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+        monkeypatch.setitem(sys.modules, "operate.utils", operate_utils)
+        monkeypatch.setitem(sys.modules, "operate.utils.gnosis", operate_gnosis)
+
+        with pytest.raises(RuntimeError, match="still reports owner"):
+            transfer.transfer_service_nft(
+                ledger_api=object(), crypto=object(),
+                service_registry_address="0xreg",
+                qs_master_safe="0xqs", pearl_master_safe="0xpl",
+                service_id=99,
+            )
 
     def test_swap_service_safe_owner_uses_approve_hash_then_exec_pattern(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1348,6 +1725,11 @@ class TestTransfer:
         operate_gnosis.get_prev_owner = (  # type: ignore[attr-defined]
             lambda *, ledger_api, safe, owner: "0xprev"
         )
+        # Post-condition read: returns the post-swap owners list. Happy
+        # path = pearl present, qs absent.
+        operate_gnosis.get_owners = (  # type: ignore[attr-defined]
+            lambda *, ledger_api, safe: ["0xpearl"]
+        )
         operate_gnosis.send_safe_txs = (  # type: ignore[attr-defined]
             lambda **kw: sends.append(kw) or "0xtx"
         )
@@ -1385,6 +1767,73 @@ class TestTransfer:
         assert sends[0]["txd"] == bytes.fromhex("2200")  # approveHash
         assert sends[1]["safe"] == "0xqsafe" and sends[1]["to"] == "0xservice"
         assert sends[1]["txd"] == bytes.fromhex("3300")  # execTransaction
+
+    def test_swap_service_safe_owner_raises_when_post_condition_unmet(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both send_safe_txs calls 'succeed' (return tx hashes), but
+        post-swap getOwners() still shows the qs Safe as owner — the inner
+        execTransaction reverted with ExecutionFailure (Gnosis Safe doesn't
+        bubble that to the outer tx). The swap MUST raise so the migration
+        aborts BEFORE rename_source_for_rollback erases qs/.operate."""
+        from scripts.pearl_migration import transfer
+
+        autonomy_pkg = types.ModuleType("autonomy")
+        autonomy_chain = types.ModuleType("autonomy.chain")
+        autonomy_base = types.ModuleType("autonomy.chain.base")
+        class _FakeInstance:
+            def encode_abi(self, *, abi_element_identifier: str, args: list) -> str:
+                return "0x00"
+        class _FakeGnosisSafe:
+            @staticmethod
+            def get_instance(**kw: Any) -> Any: return _FakeInstance()
+            @staticmethod
+            def get_raw_safe_transaction_hash(**kw: Any) -> dict:
+                return {"tx_hash": "0xabcdef"}
+        autonomy_base.registry_contracts = types.SimpleNamespace(  # type: ignore[attr-defined]
+            gnosis_safe=_FakeGnosisSafe(),
+        )
+        monkeypatch.setitem(sys.modules, "autonomy", autonomy_pkg)
+        monkeypatch.setitem(sys.modules, "autonomy.chain", autonomy_chain)
+        monkeypatch.setitem(sys.modules, "autonomy.chain.base", autonomy_base)
+
+        operate_pkg = types.ModuleType("operate")
+        operate_services = types.ModuleType("operate.services")
+        operate_protocol = types.ModuleType("operate.services.protocol")
+        operate_utils = types.ModuleType("operate.utils")
+        operate_gnosis = types.ModuleType("operate.utils.gnosis")
+        operate_protocol.get_packed_signature_for_approved_hash = (  # type: ignore[attr-defined]
+            lambda *, owners: b""
+        )
+        class _SafeOperation:
+            class CALL:
+                value = 0
+        operate_gnosis.SafeOperation = _SafeOperation  # type: ignore[attr-defined]
+        operate_gnosis.get_prev_owner = (  # type: ignore[attr-defined]
+            lambda *, ledger_api, safe, owner: "0xprev"
+        )
+        # Inner-call reverted: owners still include qs Safe.
+        operate_gnosis.get_owners = (  # type: ignore[attr-defined]
+            lambda *, ledger_api, safe: ["0xqsafe"]
+        )
+        operate_gnosis.send_safe_txs = (  # type: ignore[attr-defined]
+            lambda **kw: "0xtx"
+        )
+        for name, mod in [
+            ("operate", operate_pkg),
+            ("operate.services", operate_services),
+            ("operate.services.protocol", operate_protocol),
+            ("operate.utils", operate_utils),
+            ("operate.utils.gnosis", operate_gnosis),
+        ]:
+            monkeypatch.setitem(sys.modules, name, mod)
+
+        with pytest.raises(RuntimeError, match="still has owners"):
+            transfer.swap_service_safe_owner(
+                ledger_api="LA", crypto="CR",
+                service_safe="0xservice",
+                old_owner="0xqsafe", new_owner="0xpearl",
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -2016,6 +2465,7 @@ class TestStepTransferNft:
         def fake_nft(**kw: Any) -> str:
             calls.append(kw); return "0x1"
         fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         fake_mod.transfer_service_nft = fake_nft  # type: ignore[attr-defined]
         fake_mod.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
@@ -2094,6 +2544,7 @@ class TestStepTransferNft:
         m, *_ = orch
         monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
         fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         def boom(**kw: Any) -> None:
             raise RuntimeError("nonce stale")
         fake_mod.transfer_service_nft = boom  # type: ignore[attr-defined]
@@ -2110,6 +2561,43 @@ class TestStepTransferNft:
             )
         assert "NFT transfer failed" in ei.value.reason
 
+    def test_post_condition_unknown_surfaces_unwrapped(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`PostConditionUnknown` carries critical 'DO NOT re-run blindly'
+        guidance. The step wrapper MUST surface it as an _Unmigratable
+        whose reason preserves the original message, NOT bury it inside
+        the generic 'NFT transfer failed: ...' wrap."""
+        m, *_ = orch
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        class _PCU(RuntimeError):
+            pass
+        fake_mod.PostConditionUnknown = _PCU  # type: ignore[attr-defined]
+        def post_cond_unknown(**kw: Any) -> None:
+            raise _PCU(
+                "On-chain state INDETERMINATE after Safe tx 0xMINED: "
+                "DO NOT re-run blindly."
+            )
+        fake_mod.transfer_service_nft = post_cond_unknown  # type: ignore[attr-defined]
+        fake_mod.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_transfer_nft(
+                ledger_api="LA",
+                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                registry_addr="0xreg",
+                qs_master_safe="0xqs", pearl_master_safe="0xpl",
+                token_id=42, sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        # The original "DO NOT re-run blindly" / "INDETERMINATE" message
+        # must be preserved verbatim in the unmigratable reason — without
+        # this, the user is misdirected into a re-run that double-submits.
+        assert "INDETERMINATE" in ei.value.reason
+        assert "DO NOT re-run blindly" in ei.value.reason
+        assert "NFT transfer failed" not in ei.value.reason
+
 
 class TestStepSwapServiceSafeOwner:
     """Direct unit tests for `_step_swap_service_safe_owner` — covers
@@ -2120,6 +2608,7 @@ class TestStepSwapServiceSafeOwner:
     def fake_swap(self, monkeypatch: pytest.MonkeyPatch):  # noqa: ANN201
         calls: list = []
         fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         fake_mod.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
         def fake(**kw: Any) -> None:
             calls.append(kw)
@@ -2192,6 +2681,7 @@ class TestStepSwapServiceSafeOwner:
         m, *_ = orch
         monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
         fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         fake_mod.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
         def boom(**kw: Any) -> None:
             raise RuntimeError("safe tx revert")
@@ -2207,6 +2697,40 @@ class TestStepSwapServiceSafeOwner:
         # Half-state message must call out the inconsistency.
         assert "service Safe owner swap failed" in ei.value.reason
         assert "still lists 0xqs as owner" in ei.value.reason
+
+    def test_post_condition_unknown_surfaces_unwrapped(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Same as the NFT-step test: the swap step MUST surface
+        PostConditionUnknown's verbatim 'INDETERMINATE / DO NOT re-run'
+        guidance — the worst outcome is the user re-running and having
+        rename_source_for_rollback erase qs/.operate believing success."""
+        m, *_ = orch
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        class _PCU(RuntimeError):
+            pass
+        fake_mod.PostConditionUnknown = _PCU  # type: ignore[attr-defined]
+        fake_mod.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
+        def post_cond_unknown(**kw: Any) -> None:
+            raise _PCU(
+                "On-chain state INDETERMINATE after Safe tx 0xMINED: "
+                "DO NOT re-run blindly."
+            )
+        fake_mod.swap_service_safe_owner = post_cond_unknown  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_swap_service_safe_owner(
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                service_safe="0xms", qs_master_safe="0xqs",
+                pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        assert "INDETERMINATE" in ei.value.reason
+        assert "DO NOT re-run blindly" in ei.value.reason
+        # Must NOT be wrapped under the generic "swap failed; NFT now owned"
+        # half-state framing — that misdirects the user.
+        assert "service Safe owner swap failed" not in ei.value.reason
 
 
 class TestUnmigratableExceptionInit:
@@ -2360,6 +2884,7 @@ class TestMigrateOneService:
 
         # Stub the lazy transfer-module import.
         fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         moves: list[Any] = []
         def fake_nft(**kw: Any) -> str:
             moves.append(("nft", kw)); return "0x1"
@@ -2406,6 +2931,7 @@ class TestMigrateOneService:
         monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl"])
 
         fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         nft_called: list[Any] = []
         swap_called: list[Any] = []
         fake_transfer.transfer_service_nft = lambda **kw: nft_called.append(kw)  # type: ignore[attr-defined]
@@ -2479,6 +3005,7 @@ class TestMigrateOneService:
         monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
 
         fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         def boom(**kw: Any) -> None:
             raise RuntimeError("revert: nonce stale")
         fake_transfer.transfer_service_nft = boom  # type: ignore[attr-defined]
@@ -2514,6 +3041,7 @@ class TestMigrateOneService:
         # steps would make the error message a lie — pin the contract here.
         order: list[str] = []
         fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         def fake_nft(**kw: Any) -> str:
             order.append("nft"); return "0x1"
         def swap_boom(**kw: Any) -> None:
@@ -3252,6 +3780,7 @@ class TestMigrateOneService:
         monkeypatch.setattr(m, "safe_threshold", recording_threshold)
 
         fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         fake_transfer.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
         fake_transfer.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_transfer)
@@ -3353,6 +3882,7 @@ class TestMigrateOneService:
         monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
         monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
         fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
         fake_transfer.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
         fake_transfer.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
         monkeypatch.setitem(

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -2464,6 +2464,7 @@ class TestStepTerminate:
             manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
             ensure_signable=lambda: signed.update(n=signed["n"] + 1),
             on_chain_state_cls=FakeOnChainState,
+            ledger_api=object(), qs_address="0xqs_eoa",
         )
         assert signed["n"] == 0   # never signed because already there
 
@@ -2480,6 +2481,7 @@ class TestStepTerminate:
             manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
             ensure_signable=lambda: signed.update(n=signed["n"] + 1),
             on_chain_state_cls=FakeOnChainState,
+            ledger_api=object(), qs_address="0xqs_eoa",
         )
         assert signed["n"] == 1   # ensure_signable was called
 
@@ -2495,6 +2497,7 @@ class TestStepTerminate:
             m._step_terminate(
                 manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+                ledger_api=object(), qs_address="0xqs_eoa",
             )
         assert "could not unstake/terminate" in ei.value.reason
 
@@ -2519,6 +2522,7 @@ class TestStepTerminate:
             m._step_terminate(
                 manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+                ledger_api=object(), qs_address="0xqs_eoa",
             )
         assert "post-state verification" in ei.value.reason
         assert "rpc 502" in ei.value.reason
@@ -2534,6 +2538,7 @@ class TestStepTerminate:
             m._step_terminate(
                 manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+                ledger_api=object(), qs_address="0xqs_eoa",
             )
         assert "expected PRE_REGISTRATION" in ei.value.reason
 
@@ -2556,6 +2561,7 @@ class TestStepTerminate:
             m._step_terminate(
                 manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+                ledger_api=object(), qs_address="0xqs_eoa",
             )
 
     @pytest.mark.parametrize("rpc_cls", [
@@ -2582,7 +2588,42 @@ class TestStepTerminate:
             m._step_terminate(
                 manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+                ledger_api=object(), qs_address="0xqs_eoa",
             )
+
+    def test_terminate_waits_for_funds_then_retries(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pin: an insufficient-funds error from `terminate_service_on_chain_from_safe`
+        MUST trigger the wait-and-retry helper, not bail as `_Unmigratable`.
+        The QA scenario (qs master EOA dries up between operations) is
+        exactly this — recoverable by the user topping up."""
+        m, FakeChain, FakeOnChainState = orch
+        attempts: list[int] = []
+
+        def maybe_boom(**kw: Any) -> None:
+            attempts.append(len(attempts))
+            if len(attempts) == 1:
+                raise RuntimeError("Client does not have any funds")
+
+        manager = self._manager(
+            FakeOnChainState,
+            state_seq=[
+                FakeOnChainState.DEPLOYED,         # before terminate
+                FakeOnChainState.PRE_REGISTRATION, # post-state read after retry
+            ],
+            terminate=maybe_boom,
+        )
+        balances = iter([0, 1000])
+        monkeypatch.setattr(m, "get_asset_balance", lambda *a, **kw: next(balances))
+        monkeypatch.setattr(m, "wei_to_token", lambda *a, **kw: "stub")
+        monkeypatch.setattr(m.time, "sleep", lambda s: None)
+        m._step_terminate(
+            manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+            ledger_api=object(), qs_address="0xqs_eoa",
+        )
+        assert len(attempts) == 2  # one fail, one retry-after-topup
 
 
 class TestStepTransferNft:
@@ -2612,7 +2653,7 @@ class TestStepTransferNft:
         monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
         m._step_transfer_nft(
             ledger_api="LA",
-            qs_wallet=types.SimpleNamespace(crypto="CR"),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
             registry_addr="0xreg",
             qs_master_safe="0xqs", pearl_master_safe="0xpl",
             token_id=42, sid="sc-aaa", chain_str="gnosis",
@@ -2629,7 +2670,7 @@ class TestStepTransferNft:
         with pytest.raises(m._Unmigratable) as ei:
             m._step_transfer_nft(
                 ledger_api="LA",
-                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 registry_addr="0xreg",
                 qs_master_safe="0xqs", pearl_master_safe="0xpl",
                 token_id=42, sid="sc-aaa", chain_str="gnosis",
@@ -2645,7 +2686,7 @@ class TestStepTransferNft:
         with pytest.raises(m._Unmigratable) as ei:
             m._step_transfer_nft(
                 ledger_api="LA",
-                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 registry_addr="0xreg",
                 qs_master_safe="0xqs", pearl_master_safe="0xpl",
                 token_id=42, sid="sc-aaa", chain_str="gnosis",
@@ -2661,7 +2702,7 @@ class TestStepTransferNft:
         monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
         m._step_transfer_nft(
             ledger_api="LA",
-            qs_wallet=types.SimpleNamespace(crypto="CR"),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
             registry_addr="0xreg",
             qs_master_safe="0xqs", pearl_master_safe="0xpl",
             token_id=42, sid="sc-aaa", chain_str="gnosis",
@@ -2686,7 +2727,7 @@ class TestStepTransferNft:
         with pytest.raises(m._Unmigratable) as ei:
             m._step_transfer_nft(
                 ledger_api="LA",
-                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 registry_addr="0xreg",
                 qs_master_safe="0xqs", pearl_master_safe="0xpl",
                 token_id=42, sid="sc-aaa", chain_str="gnosis",
@@ -2718,7 +2759,7 @@ class TestStepTransferNft:
         with pytest.raises(m._Unmigratable) as ei:
             m._step_transfer_nft(
                 ledger_api="LA",
-                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 registry_addr="0xreg",
                 qs_master_safe="0xqs", pearl_master_safe="0xpl",
                 token_id=42, sid="sc-aaa", chain_str="gnosis",
@@ -2730,6 +2771,43 @@ class TestStepTransferNft:
         assert "INDETERMINATE" in ei.value.reason
         assert "DO NOT re-run blindly" in ei.value.reason
         assert "NFT transfer failed" not in ei.value.reason
+
+    def test_transfer_nft_waits_for_funds_then_retries(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pin: insufficient-funds during the NFT `safeTransferFrom` MUST
+        trigger the wait-and-retry helper (qs master EOA pays gas), not
+        bail as `_Unmigratable`. Mirrors the terminate-path pin so a
+        future refactor that drops `_retry_on_funds_shortage` from this
+        site is caught locally."""
+        m, *_ = orch
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        attempts: list[int] = []
+
+        def maybe_boom(**kw: Any) -> str:
+            attempts.append(len(attempts))
+            if len(attempts) == 1:
+                raise RuntimeError("Client does not have any funds")
+            return "0x1"
+
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
+        fake_mod.transfer_service_nft = maybe_boom  # type: ignore[attr-defined]
+        fake_mod.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        balances = iter([0, 1000])
+        monkeypatch.setattr(m, "get_asset_balance", lambda *a, **kw: next(balances))
+        monkeypatch.setattr(m, "wei_to_token", lambda *a, **kw: "stub")
+        monkeypatch.setattr(m.time, "sleep", lambda s: None)
+        m._step_transfer_nft(
+            ledger_api=object(),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
+            registry_addr="0xreg",
+            qs_master_safe="0xqs", pearl_master_safe="0xpl",
+            token_id=42, sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: None,
+        )
+        assert len(attempts) == 2  # one fail, one retry-after-topup
 
 
 class TestStepSwapServiceSafeOwner:
@@ -2756,7 +2834,7 @@ class TestStepSwapServiceSafeOwner:
         signed = {"n": 0}
         monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl"])
         m._step_swap_service_safe_owner(
-            ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+            ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
             service_safe="0xms", qs_master_safe="0xqs",
             pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
             ensure_signable=lambda: signed.update(n=signed["n"] + 1),
@@ -2773,7 +2851,7 @@ class TestStepSwapServiceSafeOwner:
         monkeypatch.setattr(m, "safe_owners", boom)
         with pytest.raises(m._Unmigratable) as ei:
             m._step_swap_service_safe_owner(
-                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 service_safe="0xms", qs_master_safe="0xqs",
                 pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None,
@@ -2787,7 +2865,7 @@ class TestStepSwapServiceSafeOwner:
         monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xstranger"])
         with pytest.raises(m._Unmigratable) as ei:
             m._step_swap_service_safe_owner(
-                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 service_safe="0xms", qs_master_safe="0xqs",
                 pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None,
@@ -2801,7 +2879,7 @@ class TestStepSwapServiceSafeOwner:
         signed = {"n": 0}
         monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
         m._step_swap_service_safe_owner(
-            ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+            ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
             service_safe="0xms", qs_master_safe="0xqs",
             pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
             ensure_signable=lambda: signed.update(n=signed["n"] + 1),
@@ -2822,7 +2900,7 @@ class TestStepSwapServiceSafeOwner:
         monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
         with pytest.raises(m._Unmigratable) as ei:
             m._step_swap_service_safe_owner(
-                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 service_safe="0xms", qs_master_safe="0xqs",
                 pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None,
@@ -2854,7 +2932,7 @@ class TestStepSwapServiceSafeOwner:
         monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
         with pytest.raises(m._Unmigratable) as ei:
             m._step_swap_service_safe_owner(
-                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
                 service_safe="0xms", qs_master_safe="0xqs",
                 pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
                 ensure_signable=lambda: None,
@@ -2864,6 +2942,39 @@ class TestStepSwapServiceSafeOwner:
         # Must NOT be wrapped under the generic "swap failed; NFT now owned"
         # half-state framing — that misdirects the user.
         assert "service Safe owner swap failed" not in ei.value.reason
+
+    def test_swap_owner_waits_for_funds_then_retries(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pin: insufficient-funds during the service Safe owner swap MUST
+        trigger the wait-and-retry helper. Same risk shape as the NFT
+        transfer step — qs master EOA pays gas, can run out mid-flow."""
+        m, *_ = orch
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        attempts: list[int] = []
+
+        def maybe_boom(**kw: Any) -> None:
+            attempts.append(len(attempts))
+            if len(attempts) == 1:
+                raise RuntimeError("Client does not have any funds")
+
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.PostConditionUnknown = type("PostConditionUnknown", (RuntimeError,), {})  # type: ignore[attr-defined]
+        fake_mod.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
+        fake_mod.swap_service_safe_owner = maybe_boom  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        balances = iter([0, 1000])
+        monkeypatch.setattr(m, "get_asset_balance", lambda *a, **kw: next(balances))
+        monkeypatch.setattr(m, "wei_to_token", lambda *a, **kw: "stub")
+        monkeypatch.setattr(m.time, "sleep", lambda s: None)
+        m._step_swap_service_safe_owner(
+            ledger_api=object(),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa"),
+            service_safe="0xms", qs_master_safe="0xqs",
+            pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: None,
+        )
+        assert len(attempts) == 2  # one fail, one retry-after-topup
 
 
 class TestUnmigratableExceptionInit:
@@ -3004,7 +3115,7 @@ class TestMigrateOneService:
             FakeChain, FakeOnChainState, terminate=fake_terminate,
         )
         qs_app = types.SimpleNamespace(service_manager=lambda: manager)
-        qs_wallet = types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"})
+        qs_wallet = types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"})
         pearl_wallet = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"})
 
         monkeypatch.setattr(m, "stop_via_middleware",
@@ -3053,7 +3164,7 @@ class TestMigrateOneService:
             state_seq=[FakeOnChainState.PRE_REGISTRATION],  # already there
         )
         qs_app = types.SimpleNamespace(service_manager=lambda: manager)
-        qs_wallet = types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"})
+        qs_wallet = types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"})
         pearl_wallet = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"})
 
         monkeypatch.setattr(m, "stop_via_middleware",
@@ -3098,7 +3209,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3120,7 +3231,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3151,7 +3262,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3189,7 +3300,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3222,7 +3333,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}, address="0xqs_eoa", ledger_api=lambda **kw: object()),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path="cfg.json",
             )
@@ -3248,7 +3359,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}, address="0xqs_eoa", ledger_api=lambda **kw: object()),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path="cfg.json",
             )
@@ -3272,7 +3383,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}, address="0xqs_eoa", ledger_api=lambda **kw: object()),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3295,7 +3406,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3381,7 +3492,7 @@ class TestMigrateOneService:
         ref = _fake_service("sc-aaa", name="A", path=tmp_path)
         m._migrate_one_service(
             svc=ref, qs_app=qs_app,
-            qs_wallet=types.SimpleNamespace(crypto="CR", safes={
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={
                 FakeChain.GNOSIS: "0xqs-g", FakeChain.OPTIMISM: "0xqs-o",
             }),
             pearl_wallet=types.SimpleNamespace(safes={
@@ -3473,7 +3584,7 @@ class TestMigrateOneService:
         ref = _fake_service("sc-aaa", name="A", path=tmp_path)
         m._migrate_one_service(
             svc=ref, qs_app=qs_app,
-            qs_wallet=types.SimpleNamespace(crypto="CR", safes={
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={
                 FakeChain.GNOSIS: "0xqs-g", FakeChain.OPTIMISM: "0xqs-o",
             }),
             pearl_wallet=types.SimpleNamespace(safes={
@@ -3514,12 +3625,15 @@ class TestMigrateOneService:
         def fake_create_safe(*, chain: Any, rpc: Any) -> None:
             creates.append({"chain": chain, "rpc": rpc})
             pearl_safes[chain] = "0xpl-new"
-        pearl_wallet = types.SimpleNamespace(safes=pearl_safes, create_safe=fake_create_safe)
+        pearl_wallet = types.SimpleNamespace(
+            safes=pearl_safes, create_safe=fake_create_safe,
+            ledger_api=lambda **kw: object(), address="0xpe",
+        )
 
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         m._migrate_one_service(
             svc=ref, qs_app=qs_app,
-            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
             pearl_wallet=pearl_wallet, config_path=None,
         )
         assert len(creates) == 1
@@ -3540,12 +3654,15 @@ class TestMigrateOneService:
 
         def boom(**kw: Any) -> None:
             raise RuntimeError("rpc rejected safe deployment")
-        pearl_wallet = types.SimpleNamespace(safes={}, create_safe=boom)
+        pearl_wallet = types.SimpleNamespace(
+            safes={}, create_safe=boom, address="0xpe",
+            ledger_api=lambda **kw: object(),
+        )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=pearl_wallet, config_path=None,
             )
         assert "could not create Pearl master Safe" in ei.value.reason
@@ -3570,7 +3687,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3599,7 +3716,7 @@ class TestMigrateOneService:
         with pytest.raises(bug_cls):
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path="cfg.json",
             )
@@ -3623,12 +3740,15 @@ class TestMigrateOneService:
                             lambda operate, config_path: None)
         def buggy(**kw: Any) -> None:
             raise bug_cls("middleware refactor")
-        pearl_wallet = types.SimpleNamespace(safes={}, create_safe=buggy)
+        pearl_wallet = types.SimpleNamespace(
+            safes={}, create_safe=buggy, address="0xpe",
+            ledger_api=lambda **kw: object(),
+        )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         with pytest.raises(bug_cls):
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=pearl_wallet, config_path=None,
             )
 
@@ -3657,7 +3777,7 @@ class TestMigrateOneService:
         with pytest.raises(bug_cls):
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3681,7 +3801,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3708,7 +3828,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3734,7 +3854,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3763,7 +3883,7 @@ class TestMigrateOneService:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
                 # No Safe registered for Gnosis -> KeyError on access.
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3795,7 +3915,7 @@ class TestMigrateOneService:
             with pytest.raises(m._Unmigratable) as ei:
                 m._migrate_one_service(
                     svc=ref, qs_app=qs_app,
-                    qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                    qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                     pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                     config_path=None,
                 )
@@ -3820,7 +3940,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3842,7 +3962,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -3882,7 +4002,7 @@ class TestMigrateOneService:
         # Should complete cleanly: no signing → no threshold check.
         m._migrate_one_service(
             svc=ref, qs_app=qs_app,
-            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
             pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
             config_path=None,
         )
@@ -3921,7 +4041,7 @@ class TestMigrateOneService:
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         m._migrate_one_service(
             svc=ref, qs_app=qs_app,
-            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
             pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
             config_path=None,
         )
@@ -3947,7 +4067,7 @@ class TestMigrateOneService:
         with pytest.raises(m._Unmigratable) as ei:
             m._migrate_one_service(
                 svc=ref, qs_app=qs_app,
-                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
                 pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
                 config_path=None,
             )
@@ -4024,11 +4144,159 @@ class TestMigrateOneService:
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         m._migrate_one_service(
             svc=ref, qs_app=qs_app,
-            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            qs_wallet=types.SimpleNamespace(crypto="CR", address="0xqs_eoa", ledger_api=lambda **kw: object(), safes={FakeChain.GNOSIS: "0xqs"}),
             pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
             config_path=None,
         )
         assert called == []  # config_path None bypasses stop_via_middleware
+
+
+class TestPearlSafeFundsWait:
+    """Cover the wait-for-funds helpers introduced after the QA failure
+    where Pearl's master EOA had zero gas on gnosis. The script previously
+    flagged the service un-migratable and bailed; now it blocks until the
+    user tops up — matching the UX of olas-operate-middleware's
+    `ask_funds_in_address` (run_service.py:597)."""
+
+    def test_is_insufficient_funds_error_matches_known_phrasings(
+        self, orch: Any,
+    ) -> None:
+        m, _, _ = orch
+        assert m._is_insufficient_funds_error(
+            RuntimeError("Client does not have any funds")
+        )
+        assert m._is_insufficient_funds_error(
+            RuntimeError("insufficient funds for gas")
+        )
+        # Anything else must NOT match — we want the generic `_Unmigratable`
+        # path so the user sees the real reason instead of an infinite wait.
+        assert not m._is_insufficient_funds_error(
+            RuntimeError("rpc rejected safe deployment")
+        )
+
+    def test_wait_for_native_funds_returns_when_balance_increases(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Polls until balance > current. First call seeds `current`,
+        subsequent calls report the new balance — return as soon as it
+        rises so the caller can re-attempt Safe creation."""
+        m, _, _ = orch
+        balances = iter([100, 100, 250])
+        monkeypatch.setattr(
+            m, "get_asset_balance", lambda *a, **kw: next(balances),
+        )
+        monkeypatch.setattr(
+            m, "wei_to_token", lambda wei, chain, asset: f"{wei}wei",
+        )
+        slept: list[float] = []
+        monkeypatch.setattr(m.time, "sleep", lambda s: slept.append(s))
+        m._wait_for_native_funds(
+            ledger_api=object(),
+            address="0xpe",
+            chain_str="gnosis",
+            recipient_name="Pearl master EOA",
+        )
+        out = capsys.readouterr().out
+        # First poll saw the same balance (loop), second poll detected the
+        # increase — so we slept twice before returning.
+        assert len(slept) == 2
+        assert "Detected 150wei arrived" in out
+        assert "Pearl master EOA 0xpe" in out
+
+    def test_create_pearl_safe_waits_then_succeeds_on_insufficient_funds(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When `create_safe` first raises an insufficient-funds error
+        (the QA failure mode), the helper MUST wait for the balance to
+        increase and retry — NOT bail with `_Unmigratable` like the old
+        path did, since funding is recoverable."""
+        m, FakeChain, _ = orch
+        attempts: list[tuple[Any, Any]] = []
+
+        def create_safe(*, chain: Any, rpc: Any) -> None:
+            attempts.append((chain, rpc))
+            if len(attempts) == 1:
+                raise RuntimeError("Client does not have any funds")
+            # Second attempt: user has topped up, succeed silently.
+
+        pearl = types.SimpleNamespace(
+            safes={}, create_safe=create_safe, address="0xpe",
+        )
+        balances = iter([0, 1000])  # current=0, then post-topup=1000.
+        monkeypatch.setattr(
+            m, "get_asset_balance", lambda *a, **kw: next(balances),
+        )
+        monkeypatch.setattr(m, "wei_to_token", lambda *a, **kw: "stub")
+        monkeypatch.setattr(m.time, "sleep", lambda s: None)
+        m._create_pearl_safe_with_funds_wait(
+            pearl_wallet=pearl,
+            chain=FakeChain.GNOSIS,
+            chain_str="gnosis",
+            rpc="https://rpc/gnosis",
+            ledger_api=object(),
+        )
+        assert len(attempts) == 2
+        out = capsys.readouterr().out
+        # User-visible signal that we're waiting (not crashing) on funds.
+        assert "insufficient funds" in out
+        assert "Detected" in out
+
+    def test_wait_for_native_funds_tolerates_rpc_blip_mid_poll(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Pin: a transient RPC failure during the poll loop MUST NOT
+        crash `_wait_for_native_funds` with a confusing trace — the user
+        may already be sending the top-up tx. Warn and keep polling.
+        Without this guard, an outage during the wait silently drops the
+        migration mid-flow."""
+        m, _, _ = orch
+        # Sequence: initial read OK (0), first poll OK (still 0 -> loop),
+        # second poll RAISES (RPC blip), third poll OK (250 -> exit).
+        seq: list[Any] = [0, 0, RuntimeError("rpc 502"), 250]
+
+        def fake_balance(*a: Any, **kw: Any) -> int:
+            v = seq.pop(0)
+            if isinstance(v, BaseException):
+                raise v
+            return v
+
+        monkeypatch.setattr(m, "get_asset_balance", fake_balance)
+        monkeypatch.setattr(m, "wei_to_token", lambda wei, *a, **kw: f"{wei}wei")
+        monkeypatch.setattr(m.time, "sleep", lambda s: None)
+        m._wait_for_native_funds(
+            ledger_api=object(), address="0xpe", chain_str="gnosis",
+            recipient_name="Pearl master EOA",
+        )
+        out = capsys.readouterr().out
+        # Outage was logged and the loop continued (didn't crash).
+        assert "balance read failed" in out
+        assert "rpc 502" in out
+        # Final detection still happened.
+        assert "Detected 250wei arrived" in out
+
+    def test_create_pearl_safe_propagates_non_funds_error(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-funds error MUST surface to the caller (which wraps it
+        as `_Unmigratable` / `_DrainFailure`) rather than spinning the
+        wait loop on an unrelated failure that won't ever cure."""
+        m, FakeChain, _ = orch
+        def create_safe(*, chain: Any, rpc: Any) -> None:
+            raise RuntimeError("rpc rejected")
+        pearl = types.SimpleNamespace(
+            safes={}, create_safe=create_safe, address="0xpe",
+        )
+        with pytest.raises(RuntimeError, match="rpc rejected"):
+            m._create_pearl_safe_with_funds_wait(
+                pearl_wallet=pearl,
+                chain=FakeChain.GNOSIS,
+                chain_str="gnosis",
+                rpc="https://rpc/gnosis",
+                ledger_api=object(),
+            )
 
 
 class TestDrainMaster:
@@ -4043,10 +4311,13 @@ class TestDrainMaster:
             pearl_safes[chain] = "0xpl"
 
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=lambda **kw: {})
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=lambda **kw: {})
         pearl = types.SimpleNamespace(safes=pearl_safes,
                                       create_safe=fake_create_safe,
-                                      address="0xpe")
+                                      address="0xpe",
+                                      ledger_api=lambda **kw: object())
         m._drain_master(
             qs_wallet=qs, pearl_wallet=pearl,
             chain_rpcs={FakeChain.GNOSIS: "https://rpc/gnosis"},
@@ -4062,7 +4333,9 @@ class TestDrainMaster:
         "nothing to drain" and "silently dropped"."""
         m, FakeChain, _ = orch
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=lambda **kw: {})
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=lambda **kw: {})
         pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
                                       address="0xpe")
         m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
@@ -4079,7 +4352,9 @@ class TestDrainMaster:
             called.append({"to": withdrawal_address, "from_safe": from_safe})
             return {"0xtoken": 100}
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=fake_drain)
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=fake_drain)
         pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
                                       address="0xpe")
         failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
@@ -4097,7 +4372,9 @@ class TestDrainMaster:
                 raise RuntimeError("safe drain boom")
             return {}
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=fake_drain)
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=fake_drain)
         pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
                                       address="0xpe")
         failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
@@ -4115,7 +4392,9 @@ class TestDrainMaster:
                 raise RuntimeError("eoa drain boom")
             return {}
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=fake_drain)
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=fake_drain)
         pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
                                       address="0xpe")
         failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
@@ -4142,10 +4421,13 @@ class TestDrainMaster:
             return {}
 
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=fake_drain)
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=fake_drain)
         pearl = types.SimpleNamespace(safes=pearl_safes,
                                       create_safe=fake_create_safe,
-                                      address="0xpe")
+                                      address="0xpe",
+                                      ledger_api=lambda **kw: object())
         failures = m._drain_master(
             qs_wallet=qs, pearl_wallet=pearl,
             chain_rpcs={FakeChain.GNOSIS: "https://rpc.example/gnosis"},
@@ -4171,7 +4453,9 @@ class TestDrainMaster:
         def buggy_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict:
             raise bug_cls("simulated middleware refactor bug")
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=buggy_drain)
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=buggy_drain)
         pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
                                       address="0xpe")
         with pytest.raises(bug_cls):
@@ -4188,9 +4472,12 @@ class TestDrainMaster:
         def buggy_create(*, chain: Any, rpc: Any) -> None:
             raise bug_cls("simulated middleware refactor bug")
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=lambda **kw: {})
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=lambda **kw: {})
         pearl = types.SimpleNamespace(safes={}, create_safe=buggy_create,
-                                      address="0xpe")
+                                      address="0xpe",
+                                      ledger_api=lambda **kw: object())
         with pytest.raises(bug_cls):
             m._drain_master(
                 qs_wallet=qs, pearl_wallet=pearl,
@@ -4205,8 +4492,11 @@ class TestDrainMaster:
         def boom(*, chain: Any, rpc: Any) -> None:
             raise RuntimeError("create reverted")
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=lambda **kw: {})
-        pearl = types.SimpleNamespace(safes={}, create_safe=boom, address="0xpe")
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=lambda **kw: {})
+        pearl = types.SimpleNamespace(safes={}, create_safe=boom, address="0xpe",
+                                      ledger_api=lambda **kw: object())
         # Provide an RPC so the create_safe boom is reached (new pre-check
         # would short-circuit otherwise).
         failures = m._drain_master(
@@ -4231,9 +4521,12 @@ class TestDrainMaster:
         def fake_create_safe(*, chain: Any, rpc: Any) -> None:
             creates.append(chain)
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=lambda **kw: {})
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=lambda **kw: {})
         pearl = types.SimpleNamespace(safes={}, create_safe=fake_create_safe,
-                                      address="0xpe")
+                                      address="0xpe",
+                                      ledger_api=lambda **kw: object())
         failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl, chain_rpcs={})
         # create_safe MUST NOT have been called with rpc=None.
         assert creates == []
@@ -4262,10 +4555,12 @@ class TestDrainMaster:
         qs = types.SimpleNamespace(
             safes={FakeChain.GNOSIS: "0xqs-g", FakeChain.OPTIMISM: "0xqs-o"},
             address="0xqs_eoa", drain=fake_drain,
+            ledger_api=lambda **kw: object(),
         )
         pearl = types.SimpleNamespace(
             safes={FakeChain.OPTIMISM: "0xpl-o"},   # missing GNOSIS
             create_safe=fake_create_safe, address="0xpe",
+            ledger_api=lambda **kw: object(),
         )
         failures = m._drain_master(
             qs_wallet=qs, pearl_wallet=pearl,
@@ -4296,7 +4591,9 @@ class TestDrainMaster:
                 raise RuntimeError("safe drain boom")
             return {}
         qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
-                                   address="0xqs_eoa", drain=fake_drain)
+                                   address="0xqs_eoa",
+                                   ledger_api=lambda **kw: object(),
+                                   drain=fake_drain)
         pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
                                       address="0xpe")
         m._drain_master(qs_wallet=qs, pearl_wallet=pearl)

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -1450,6 +1450,24 @@ class TestStop:
         monkeypatch.setattr(stop.subprocess, "run", boom)
         assert stop.force_remove_known_containers() == []
 
+    def test_force_remove_known_containers_raises_on_nonzero_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-zero `docker rm -f` exit (daemon refused, permission
+        denied on /var/run/docker.sock) must raise — the docstring's
+        "don't proceed against still-running deployment" guarantee
+        depends on it."""
+        from scripts.pearl_migration import stop
+        monkeypatch.setattr(stop, "docker_quickstart_containers", lambda: ["abci0"])
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise subprocess.CalledProcessError(
+                returncode=1, cmd=["docker", "rm", "-f", "abci0"],
+                stderr=b"permission denied",
+            )
+        monkeypatch.setattr(stop.subprocess, "run", boom)
+        with pytest.raises(RuntimeError, match="exited 1.*permission denied"):
+            stop.force_remove_known_containers()
+
 
 # ---------------------------------------------------------------------------
 # transfer.py
@@ -2250,6 +2268,58 @@ class TestRunModeA:
         )
         m._run_mode_a(disc=d, dry_run=True)
         assert "Would back up" in capsys.readouterr().out
+
+    def test_mode_a_re_probe_failure_is_fatal(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mode A re-probes via `docker_quickstart_containers` after
+        `force_remove_known_containers()` returned cleanly. If `docker ps`
+        itself raises (daemon hung mid-cleanup), Mode A must `fatal()`
+        — proceeding to copy `.operate/` while the deployment may still
+        be writing would corrupt the Pearl store, and the subsequent
+        rename would make it unrecoverable."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        _write_service(qs_root, "sc-aaa", agent_addresses=["0xa"])
+        _write_key(qs_root, "0xa")
+        _write_wallet(qs_root)
+        pl_root = tmp_path / "pl/.operate"
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root.resolve()),
+            pearl=detect.OperateStore(root=pl_root.resolve()),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        def boom() -> list:
+            raise RuntimeError("docker daemon hung")
+        monkeypatch.setattr(m, "docker_quickstart_containers", boom)
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        with pytest.raises(SystemExit):
+            m._run_mode_a(disc=d, dry_run=False)
+
+    def test_mode_a_re_probe_finds_remaining_containers_is_fatal(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`force_remove_known_containers()` may return cleanly even
+        when the docker daemon refused the rm with a non-zero exit (the
+        old `check=False` behavior). The re-probe is the safety net —
+        if it sees containers still present, Mode A must `fatal()`."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        _write_service(qs_root, "sc-aaa", agent_addresses=["0xa"])
+        _write_key(qs_root, "0xa")
+        _write_wallet(qs_root)
+        pl_root = tmp_path / "pl/.operate"
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root.resolve()),
+            pearl=detect.OperateStore(root=pl_root.resolve()),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "docker_quickstart_containers", lambda: ["abci0"])
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        with pytest.raises(SystemExit):
+            m._run_mode_a(disc=d, dry_run=False)
 
     def test_force_cleanup_failure_is_fatal_in_mode_a(
         self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -1,0 +1,3942 @@
+"""Unit tests for scripts.pearl_migration.
+
+Covers discovery, filesystem copy + collisions, prompts, status helpers,
+the orchestrator, and the on-chain transfer wrappers (with mocks). The
+goal is 100% line coverage of `scripts.pearl_migration` so the project
+keeps satisfying `--cov-fail-under=100`.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import types
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import pytest
+
+from scripts.pearl_migration import detect, filesystem, prompts, status
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_wallet(operate_root: Path, master_eoa: str = "0xeoa") -> None:
+    wallets = operate_root / "wallets"
+    wallets.mkdir(parents=True, exist_ok=True)
+    (wallets / "ethereum.json").write_text(json.dumps({
+        "address": master_eoa,
+        "safes": {"gnosis": "0xsafe"},
+        "safe_chains": ["gnosis"],
+        "ledger_type": "ethereum",
+    }))
+    (wallets / "ethereum.txt").write_text("encrypted-master-key")
+
+
+def _write_service(
+    operate_root: Path,
+    config_id: str,
+    name: str = "Trader Agent",
+    agent_addresses: list[str] | None = None,
+) -> Path:
+    sdir = operate_root / "services" / config_id
+    sdir.mkdir(parents=True, exist_ok=True)
+    (sdir / "config.json").write_text(json.dumps({
+        "name": name,
+        "service_config_id": config_id,
+        "agent_addresses": agent_addresses or ["0xagent1"],
+        "hash": "bafy-test",
+    }))
+    (sdir / "persistent_data").mkdir()
+    (sdir / "persistent_data" / "log.txt").write_text("hello")
+    return sdir
+
+
+def _write_key(operate_root: Path, addr: str) -> None:
+    keys = operate_root / "keys"
+    keys.mkdir(parents=True, exist_ok=True)
+    (keys / addr).write_text(json.dumps({"address": addr, "private_key": "enc"}))
+
+
+def _fake_service(
+    config_id: str,
+    *,
+    name: str = "Test Service",
+    agent_addresses: list[str] | None = None,
+    path: Path | None = None,
+    hash_: str = "bafy-test",
+    chain_configs: dict | None = None,
+) -> Any:
+    """Build a duck-typed stand-in for `operate.services.service.Service`.
+
+    The real Service requires a fully-formed config.json (12+ fields, nested
+    dataclasses for AgentRelease / ChainConfigs / etc.). For unit tests we
+    only need the attributes the migration code actually reads, so a
+    `SimpleNamespace` with those fields keeps the fixtures small.
+    """
+    import types
+    return types.SimpleNamespace(
+        service_config_id=config_id,
+        name=name,
+        agent_addresses=list(agent_addresses or []),
+        path=path or Path(f"/tmp/{config_id}"),
+        hash=hash_,
+        chain_configs=chain_configs if chain_configs is not None else {},
+    )
+
+
+@pytest.fixture
+def patch_service_load(monkeypatch: pytest.MonkeyPatch):
+    """Monkeypatch `detect.Service.load` to return fake services.
+
+    Yields the mapping dict; tests register entries keyed by the source
+    directory path. Any path not in the map raises (so missed expectations
+    don't silently pass via the swallow-exceptions branch in `services()`).
+    """
+    registry: dict[Path, Any] = {}
+
+    def _fake_load(path: Path) -> Any:
+        resolved = path.resolve() if isinstance(path, Path) else Path(path).resolve()
+        if resolved not in registry:
+            raise RuntimeError(f"_fake_load: no fake registered for {resolved}")
+        return registry[resolved]
+
+    monkeypatch.setattr(detect.Service, "load", staticmethod(_fake_load))
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# detect.py
+# ---------------------------------------------------------------------------
+
+class TestDiscover:
+    def test_noop_when_paths_resolve_equal(self, tmp_path: Path) -> None:
+        # Both stores point at the same .operate
+        store = tmp_path / ".operate"
+        store.mkdir()
+        d = detect.discover(quickstart_root=store, pearl_root=store)
+        assert d.mode is detect.Mode.NOOP
+
+    def test_fresh_copy_when_pearl_missing(self, tmp_path: Path) -> None:
+        qs = tmp_path / "qs/.operate"
+        qs.mkdir(parents=True)
+        pl = tmp_path / "home/.operate"
+        d = detect.discover(quickstart_root=qs, pearl_root=pl)
+        assert d.mode is detect.Mode.FRESH_COPY
+
+    def test_fresh_copy_when_pearl_exists_but_empty(self, tmp_path: Path) -> None:
+        qs = tmp_path / "qs/.operate"
+        qs.mkdir(parents=True)
+        pl = tmp_path / "home/.operate"
+        pl.mkdir(parents=True)  # exists, but no wallet
+        d = detect.discover(quickstart_root=qs, pearl_root=pl)
+        assert d.mode is detect.Mode.FRESH_COPY
+
+    def test_merge_when_pearl_has_wallet(self, tmp_path: Path) -> None:
+        qs = tmp_path / "qs/.operate"
+        qs.mkdir(parents=True)
+        pl = tmp_path / "home/.operate"
+        pl.mkdir(parents=True)
+        _write_wallet(pl)
+        d = detect.discover(quickstart_root=qs, pearl_root=pl)
+        assert d.mode is detect.Mode.MERGE
+
+
+class TestListServices:
+    def test_lists_only_sc_prefixed_dirs_with_config(
+        self, tmp_path: Path, patch_service_load: dict[Path, Any]
+    ) -> None:
+        root = tmp_path / ".operate"
+        _write_service(root, "sc-aaa", name="A", agent_addresses=["0x1", "0x2"])
+        _write_service(root, "sc-bbb", name="B", agent_addresses=["0x3"])
+        # Decoy: directory not prefixed
+        (root / "services" / "garbage").mkdir(parents=True)
+        # Decoy: missing config.json
+        (root / "services" / "sc-empty").mkdir()
+
+        # Register fakes for the two valid sc-* dirs. The decoys never
+        # reach Service.load (filtered out by the prefix / config.json
+        # checks in OperateStore.services()).
+        patch_service_load[(root / "services/sc-aaa").resolve()] = _fake_service(
+            "sc-aaa", name="A", agent_addresses=["0x1", "0x2"],
+        )
+        patch_service_load[(root / "services/sc-bbb").resolve()] = _fake_service(
+            "sc-bbb", name="B", agent_addresses=["0x3"],
+        )
+
+        store = detect.OperateStore(root=root.resolve())
+        svcs = store.services()
+        ids = [s.service_config_id for s in svcs]
+        assert ids == ["sc-aaa", "sc-bbb"]
+        assert svcs[0].name == "A"
+        assert svcs[0].agent_addresses == ["0x1", "0x2"]
+
+    def test_services_swallows_load_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bad service should be skipped, not abort the whole listing."""
+        root = tmp_path / ".operate"
+        _write_service(root, "sc-aaa")
+        _write_service(root, "sc-bbb")
+
+        good = _fake_service("sc-bbb", name="B")
+
+        def _flaky_load(path: Path) -> Any:
+            if path.name == "sc-aaa":
+                raise RuntimeError("corrupt config")
+            return good
+
+        monkeypatch.setattr(detect.Service, "load", staticmethod(_flaky_load))
+        store = detect.OperateStore(root=root.resolve())
+        assert [s.service_config_id for s in store.services()] == ["sc-bbb"]
+
+
+# ---------------------------------------------------------------------------
+# filesystem.py
+# ---------------------------------------------------------------------------
+
+class TestFreshCopy:
+    def test_copies_whole_tree(self, tmp_path: Path) -> None:
+        src_root = tmp_path / "src/.operate"
+        _write_service(src_root, "sc-aaa", agent_addresses=["0xagent"])
+        _write_key(src_root, "0xagent")
+        _write_wallet(src_root)
+        src = detect.OperateStore(root=src_root.resolve())
+
+        dest = tmp_path / "home/.operate"
+        filesystem.fresh_copy_store(src, dest)
+        assert (dest / "wallets" / "ethereum.json").exists()
+        assert (dest / "services" / "sc-aaa" / "config.json").exists()
+        assert (dest / "keys" / "0xagent").exists()
+
+    def test_refuses_existing_dest(self, tmp_path: Path) -> None:
+        src_root = tmp_path / "src/.operate"
+        src_root.mkdir(parents=True)
+        src = detect.OperateStore(root=src_root.resolve())
+        dest = tmp_path / "home/.operate"
+        dest.mkdir(parents=True)
+        with pytest.raises(FileExistsError):
+            filesystem.fresh_copy_store(src, dest)
+
+
+class TestMergeService:
+    def _setup(
+        self, tmp_path: Path,
+    ) -> tuple[detect.OperateStore, detect.OperateStore, Any]:
+        src_root = tmp_path / "src/.operate"
+        _write_service(src_root, "sc-aaa", agent_addresses=["0xagent1"])
+        _write_key(src_root, "0xagent1")
+        src = detect.OperateStore(root=src_root.resolve())
+
+        dest_root = tmp_path / "dest/.operate"
+        dest_root.mkdir(parents=True)
+        _write_wallet(dest_root, master_eoa="0xpearl")
+        dest = detect.OperateStore(root=dest_root.resolve())
+
+        svc = _fake_service(
+            "sc-aaa",
+            agent_addresses=["0xagent1"],
+            path=(src_root / "services" / "sc-aaa").resolve(),
+        )
+        return src, dest, svc
+
+    def test_clean_merge_copies_service_and_key(self, tmp_path: Path) -> None:
+        src, dest, svc = self._setup(tmp_path)
+        outcome = filesystem.merge_service(svc, src, dest)
+        assert outcome.service_copied is True
+        assert outcome.keys_copied == ["0xagent1"]
+        assert (dest.services_dir / "sc-aaa" / "config.json").exists()
+        assert (dest.keys_dir / "0xagent1").exists()
+
+    def test_collision_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        src, dest, svc = self._setup(tmp_path)
+        # Pre-create a colliding service dir.
+        (dest.services_dir / "sc-aaa").mkdir(parents=True)
+        (dest.services_dir / "sc-aaa" / "marker.txt").write_text("dest-original")
+        # And a colliding key.
+        (dest.keys_dir).mkdir(parents=True, exist_ok=True)
+        (dest.keys_dir / "0xagent1").write_text("dest-key")
+
+        # Always pick "skip".
+        monkeypatch.setattr(
+            filesystem, "collision",
+            lambda target, kind: prompts.CollisionChoice.SKIP,
+        )
+
+        outcome = filesystem.merge_service(svc, src, dest)
+        assert outcome.service_skipped is True
+        assert outcome.keys_skipped == ["0xagent1"]
+        assert (dest.services_dir / "sc-aaa" / "marker.txt").read_text() == "dest-original"
+        assert (dest.keys_dir / "0xagent1").read_text() == "dest-key"
+        assert outcome.backups_made == []
+
+    def test_collision_overwrite_with_backup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        src, dest, svc = self._setup(tmp_path)
+        (dest.services_dir / "sc-aaa").mkdir(parents=True)
+        (dest.services_dir / "sc-aaa" / "marker.txt").write_text("dest-original")
+        (dest.keys_dir).mkdir(parents=True, exist_ok=True)
+        (dest.keys_dir / "0xagent1").write_text("dest-key")
+
+        monkeypatch.setattr(
+            filesystem, "collision",
+            lambda target, kind: prompts.CollisionChoice.OVERWRITE_WITH_BACKUP,
+        )
+
+        outcome = filesystem.merge_service(svc, src, dest)
+        assert outcome.service_copied is True
+        assert outcome.keys_copied == ["0xagent1"]
+        # Backups exist for each collision.
+        assert len(outcome.backups_made) == 2
+        for bak in outcome.backups_made:
+            assert bak.exists()
+        # Fresh copy in place.
+        assert (dest.services_dir / "sc-aaa" / "config.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# prompts.py
+# ---------------------------------------------------------------------------
+
+class TestPrompts:
+    @pytest.fixture(autouse=True)
+    def _attended_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force ATTENDED=true so the middleware helper goes down the input()
+        # path. Tests that want unattended mode override this explicitly.
+        monkeypatch.setenv("ATTENDED", "true")
+
+    def test_yes_no_explicit_yes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        assert prompts.yes_no("?", default=False) is True
+
+    def test_yes_no_explicit_no(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        assert prompts.yes_no("?", default=True) is False
+
+    def test_yes_no_rejects_garbage_then_accepts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        answers = iter(["maybe", "perhaps", "no"])
+        monkeypatch.setattr("builtins.input", lambda _: next(answers))
+        assert prompts.yes_no("?", default=True) is False
+
+    def test_yes_no_unattended_returns_default_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATTENDED", "false")
+        # No input mock — would hang if middleware were called.
+        assert prompts.yes_no("?", default=True) is True
+
+    def test_yes_no_unattended_returns_default_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATTENDED", "false")
+        assert prompts.yes_no("?", default=False) is False
+
+    def test_yes_no_unattended_no_default_returns_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No declared default in unattended mode -> match middleware's
+        # "yes to everything" assumption.
+        monkeypatch.setenv("ATTENDED", "false")
+        assert prompts.yes_no("?") is True
+
+    def test_yes_no_attended_no_default_delegates_to_middleware(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # `default=None` in attended mode -> delegate to middleware loop.
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        assert prompts.yes_no("?") is True
+
+    def test_yes_no_attended_default_honors_empty_input(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With a declared default, empty input picks the default (legacy [Y/n] feel).
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        assert prompts.yes_no("?", default=True) is True
+        assert prompts.yes_no("?", default=False) is False
+
+    def test_yes_no_eof_returns_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Closed/piped stdin in attended mode falls back to the
+        declared default — the rename-source and "different machine?"
+        prompts at the end of a successful migration both pass an
+        explicit default, so this avoids a raw EOFError traceback at
+        the very end of a working migration."""
+        def boom(_: str) -> str:
+            raise EOFError
+        monkeypatch.setattr("builtins.input", boom)
+        assert prompts.yes_no("?", default=True) is True
+        assert prompts.yes_no("?", default=False) is False
+
+    def test_collision_eof_defaults_to_skip(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`collision()` is invoked from `merge_service` AFTER on-chain
+        ops have committed. A raw EOFError traceback here would abort
+        the for-loop, skip drain + rename, and leave the user with no
+        summary. Default to SKIP (the safe choice) and warn so it's
+        visible."""
+        def boom(_: str) -> str:
+            raise EOFError
+        monkeypatch.setattr("builtins.input", boom)
+        result = prompts.collision(tmp_path / "x", kind="key")
+        assert result == prompts.CollisionChoice.SKIP
+        assert "stdin closed" in capsys.readouterr().out
+
+    def test_collision_invalid_input_re_prompts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Invalid input must surface a hint rather than silently
+        re-prompt forever — easier to spot mistyped input."""
+        answers = iter(["3", "foo", "1"])
+        monkeypatch.setattr("builtins.input", lambda _: next(answers))
+        result = prompts.collision(tmp_path / "x", kind="key")
+        assert result == prompts.CollisionChoice.SKIP
+        out = capsys.readouterr().out
+        assert "Invalid choice" in out
+
+    def test_ask_password_validating_succeeds_within_attempts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        answers = iter(["wrong", "right"])
+        monkeypatch.setattr(prompts, "password", lambda _: next(answers))
+        result = prompts.ask_password_validating(
+            prompt="pw: ",
+            validate=lambda p: p == "right",
+            attempts=3,
+        )
+        assert result == "right"
+
+    def test_ask_password_validating_returns_none_on_exhaustion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(prompts, "password", lambda _: "wrong")
+        result = prompts.ask_password_validating(
+            prompt="pw: ",
+            validate=lambda _: False,
+            attempts=2,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# status.py (the OS-level bits — no mocking of the chain here)
+# ---------------------------------------------------------------------------
+
+class TestStatusOSChecks:
+    def test_pearl_daemon_running_false_on_unused_port(self) -> None:
+        # Port 1 is privileged + nothing listens on it under tests.
+        assert status.pearl_daemon_running(port=1) is False
+
+    def test_is_root_owned_false_for_user_path(self, tmp_path: Path) -> None:
+        f = tmp_path / "x"
+        f.write_text("hi")
+        assert status.is_root_owned(f) is False
+
+    def test_is_root_owned_false_for_missing_path(self, tmp_path: Path) -> None:
+        assert status.is_root_owned(tmp_path / "doesnt-exist") is False
+
+    def test_any_root_owned_under_handles_missing(self, tmp_path: Path) -> None:
+        assert status.any_root_owned_under(tmp_path / "doesnt-exist") is False
+
+    def test_pearl_daemon_running_true_when_listening(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stand up a real localhost listener — conftest allows 127.0.0.1.
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        try:
+            assert status.pearl_daemon_running(port=port) is True
+        finally:
+            srv.close()
+
+    def test_docker_quickstart_containers_returns_intersection(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout="abci0\nnode0\nrandom_other\n",
+        )
+        monkeypatch.setattr(status.subprocess, "run", lambda *a, **k: completed)
+        assert status.docker_quickstart_containers() == ["abci0", "node0"]
+
+    def test_docker_quickstart_containers_handles_missing_docker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise FileNotFoundError("docker not installed")
+        monkeypatch.setattr(status.subprocess, "run", boom)
+        assert status.docker_quickstart_containers() == []
+
+    def test_docker_quickstart_containers_propagates_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A hung docker daemon must NOT be silently mistaken for "no containers".
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise subprocess.TimeoutExpired(cmd="docker", timeout=10)
+        monkeypatch.setattr(status.subprocess, "run", boom)
+        with pytest.raises(subprocess.TimeoutExpired):
+            status.docker_quickstart_containers()
+
+    def test_docker_quickstart_containers_raises_on_nonzero_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-zero exit from `docker ps` (permission denied on
+        /var/run/docker.sock, daemon refusing) MUST raise. Returning
+        `[]` would let callers conclude "no containers" and race a
+        still-running deployment."""
+        def fake_run(*_a: Any, **_k: Any) -> Any:
+            return types.SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="permission denied while trying to connect to "
+                       "the Docker daemon socket",
+            )
+        monkeypatch.setattr(status.subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="exited 1"):
+            status.docker_quickstart_containers()
+
+    def test_is_root_owned_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        f = tmp_path / "x"
+        f.write_text("hi")
+
+        class FakeStat:
+            st_uid = 0
+
+        monkeypatch.setattr(Path, "stat", lambda self: FakeStat())
+        assert status.is_root_owned(f) is True
+
+    def test_is_root_owned_propagates_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OSError from stat() (e.g. permission denied) MUST propagate.
+        Returning False would let `fix_root_ownership` skip chown and
+        the subsequent copytree would corrupt the destination."""
+        f = tmp_path / "x"
+        f.write_text("hi")
+        monkeypatch.setattr(Path, "exists", lambda self: True)
+        def boom(self: Path) -> None:
+            raise OSError("permission denied")
+        monkeypatch.setattr(Path, "stat", boom)
+        with pytest.raises(OSError, match="permission denied"):
+            status.is_root_owned(f)
+
+    def test_any_root_owned_under_root_itself(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(status, "is_root_owned", lambda p: True)
+        assert status.any_root_owned_under(tmp_path) is True
+
+    def test_any_root_owned_under_descendant(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import stat as _statmod
+        child = tmp_path / "child"
+        child.write_text("x")
+
+        # Root not owned by root, but the child is.
+        monkeypatch.setattr(status, "is_root_owned", lambda p: False)
+
+        class FakeStatRoot:
+            st_uid = 1000
+            st_mode = _statmod.S_IFDIR | 0o755
+
+        class FakeStatChild:
+            st_uid = 0
+            st_mode = _statmod.S_IFREG | 0o644
+
+        def fake_stat(self: Path) -> Any:
+            return FakeStatChild() if self == child else FakeStatRoot()
+        monkeypatch.setattr(Path, "stat", fake_stat)
+        assert status.any_root_owned_under(tmp_path) is True
+
+    def test_any_root_owned_under_returns_false_when_clean(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Walking the tree to completion without finding any root-owned
+        file returns False — covers the loop-falls-through branch.
+        Real files owned by the current user (not 0) — no stat() mocking
+        needed (rglob calls is_dir() which would otherwise break a stub)."""
+        (tmp_path / "a").write_text("hi")
+        (tmp_path / "b").write_text("hi")
+        monkeypatch.setattr(status, "is_root_owned", lambda p: False)
+        assert status.any_root_owned_under(tmp_path) is False
+
+    def test_any_root_owned_under_propagates_descendant_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A permission error walking the tree means we can't tell
+        whether a root-owned file is hiding beneath. Returning False
+        would silently skip chown and corrupt the destination copy —
+        propagate so `fix_root_ownership` aborts."""
+        (tmp_path / "x").write_text("hi")
+        monkeypatch.setattr(status, "is_root_owned", lambda p: False)
+
+        original_stat = Path.stat
+
+        def stat_raises_for_child(self: Path) -> Any:
+            if self.name == "x":
+                raise OSError("permission")
+            return original_stat(self)
+        monkeypatch.setattr(Path, "stat", stat_raises_for_child)
+        with pytest.raises(OSError, match="permission"):
+            status.any_root_owned_under(tmp_path)
+
+    def test_any_root_owned_under_propagates_rglob_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """rglob() failure is the same hazard as descendant stat failure
+        — propagate, don't silently report 'no root-owned files'."""
+        monkeypatch.setattr(status, "is_root_owned", lambda p: False)
+
+        def rglob_raises(self: Path, pattern: str) -> Iterable[Path]:
+            raise OSError("nope")
+        monkeypatch.setattr(Path, "rglob", rglob_raises)
+        with pytest.raises(OSError, match="nope"):
+            status.any_root_owned_under(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# status.py — on-chain query wrappers (mocked)
+# ---------------------------------------------------------------------------
+
+def _install_fake_autonomy(monkeypatch: pytest.MonkeyPatch, registry_obj: Any) -> None:
+    """Install a stub `autonomy.chain.base` exposing a `registry_contracts` attribute."""
+    autonomy_pkg = types.ModuleType("autonomy")
+    autonomy_chain = types.ModuleType("autonomy.chain")
+    autonomy_chain_base = types.ModuleType("autonomy.chain.base")
+    autonomy_chain_base.registry_contracts = registry_obj  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "autonomy", autonomy_pkg)
+    monkeypatch.setitem(sys.modules, "autonomy.chain", autonomy_chain)
+    monkeypatch.setitem(sys.modules, "autonomy.chain.base", autonomy_chain_base)
+
+
+class TestStatusOnChain:
+    def test_service_nft_owner_returns_owner(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        instance = types.SimpleNamespace(
+            functions=types.SimpleNamespace(
+                ownerOf=lambda sid: types.SimpleNamespace(call=lambda: "0xowner"),
+            )
+        )
+        registry = types.SimpleNamespace(
+            service_registry=types.SimpleNamespace(
+                get_instance=lambda **kw: instance,
+            ),
+        )
+        _install_fake_autonomy(monkeypatch, registry)
+        assert status.service_nft_owner(
+            ledger_api=object(),
+            service_registry_address="0xreg",
+            service_id=42,
+        ) == "0xowner"
+
+    def test_service_nft_owner_returns_none_on_revert(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from web3.exceptions import ContractLogicError
+        instance = types.SimpleNamespace(
+            functions=types.SimpleNamespace(
+                ownerOf=lambda sid: types.SimpleNamespace(
+                    call=lambda: (_ for _ in ()).throw(ContractLogicError("revert: NOT_MINTED")),
+                ),
+            ),
+        )
+        registry = types.SimpleNamespace(
+            service_registry=types.SimpleNamespace(
+                get_instance=lambda **kw: instance,
+            ),
+        )
+        _install_fake_autonomy(monkeypatch, registry)
+        assert status.service_nft_owner(
+            ledger_api=object(),
+            service_registry_address="0xreg",
+            service_id=42,
+        ) is None
+
+    def test_service_nft_owner_propagates_other_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Network/RPC errors must NOT be collapsed into "owner unknown".
+        instance = types.SimpleNamespace(
+            functions=types.SimpleNamespace(
+                ownerOf=lambda sid: types.SimpleNamespace(
+                    call=lambda: (_ for _ in ()).throw(ConnectionError("rpc down")),
+                ),
+            ),
+        )
+        registry = types.SimpleNamespace(
+            service_registry=types.SimpleNamespace(
+                get_instance=lambda **kw: instance,
+            ),
+        )
+        _install_fake_autonomy(monkeypatch, registry)
+        with pytest.raises(ConnectionError):
+            status.service_nft_owner(
+                ledger_api=object(),
+                service_registry_address="0xreg",
+                service_id=42,
+            )
+
+    def test_safe_owners_uses_gnosis_helper(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        operate_pkg = types.ModuleType("operate")
+        operate_utils = types.ModuleType("operate.utils")
+        operate_gnosis = types.ModuleType("operate.utils.gnosis")
+        operate_gnosis.get_owners = lambda ledger_api, safe: ["0xa", "0xb"]  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+        monkeypatch.setitem(sys.modules, "operate.utils", operate_utils)
+        monkeypatch.setitem(sys.modules, "operate.utils.gnosis", operate_gnosis)
+
+        assert status.safe_owners(ledger_api=object(), safe="0xs") == ["0xa", "0xb"]
+
+    def test_safe_threshold_returns_int(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        instance = types.SimpleNamespace(
+            functions=types.SimpleNamespace(
+                getThreshold=lambda: types.SimpleNamespace(call=lambda: 2),
+            )
+        )
+        registry = types.SimpleNamespace(
+            gnosis_safe=types.SimpleNamespace(
+                get_instance=lambda **kw: instance,
+            ),
+        )
+        _install_fake_autonomy(monkeypatch, registry)
+        assert status.safe_threshold(ledger_api=object(), safe="0xs") == 2
+
+
+# ---------------------------------------------------------------------------
+# detect.py — additional branches
+# ---------------------------------------------------------------------------
+
+class TestDetectExtras:
+    def test_list_services_returns_empty_when_no_services_dir(
+        self, tmp_path: Path
+    ) -> None:
+        store = detect.OperateStore(root=tmp_path)
+        assert store.services() == []
+
+    def test_list_services_skips_malformed_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sdir = tmp_path / "services" / "sc-bad"
+        sdir.mkdir(parents=True)
+        (sdir / "config.json").write_text("{ this is not json")
+
+        def _boom(_: Path) -> Any:
+            raise RuntimeError("malformed")
+        monkeypatch.setattr(detect.Service, "load", staticmethod(_boom))
+
+        store = detect.OperateStore(root=tmp_path)
+        assert store.services() == []
+
+    def test_operate_app_lazy_build_and_caching(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`operate_app()` defers OperateApp construction and reuses on repeat calls."""
+        instances: list[Any] = []
+
+        class FakeApp:
+            def __init__(self, home: Path) -> None:
+                self.home = home
+                self.password = None
+                instances.append(self)
+
+        # Insert a fake `operate.cli` so the lazy `from operate.cli import OperateApp`
+        # picks it up.
+        import sys, types
+        fake_cli = types.ModuleType("operate.cli")
+        fake_cli.OperateApp = FakeApp  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate.cli", fake_cli)
+
+        store = detect.OperateStore(root=tmp_path)
+        # First call with password → constructs and assigns.
+        app1 = store.operate_app(password="pw1")
+        assert isinstance(app1, FakeApp)
+        assert app1.password == "pw1"
+        # Second call with a different password → reuses cached app, sets pw.
+        app2 = store.operate_app(password="pw2")
+        assert app2 is app1
+        assert app1.password == "pw2"
+        # Third call without a password → still cached, pw unchanged.
+        app3 = store.operate_app()
+        assert app3 is app1
+        assert app1.password == "pw2"
+        assert len(instances) == 1
+
+    def test_operate_app_first_call_without_password(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys, types
+        class FakeApp:
+            def __init__(self, home: Path) -> None:
+                self.home = home
+                self.password = "preset"
+
+        fake_cli = types.ModuleType("operate.cli")
+        fake_cli.OperateApp = FakeApp  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate.cli", fake_cli)
+
+        store = detect.OperateStore(root=tmp_path)
+        app = store.operate_app()  # no password
+        assert app.password == "preset"  # didn't overwrite
+
+    def test_discovery_is_noop_property(self, tmp_path: Path) -> None:
+        store = detect.OperateStore(root=tmp_path.resolve())
+        d = detect.Discovery(quickstart=store, pearl=store, mode=detect.Mode.NOOP)
+        assert d.is_noop is True
+        # Distinct stores → can construct with non-NOOP mode.
+        store2 = detect.OperateStore(root=(tmp_path / "other").resolve())
+        d2 = detect.Discovery(quickstart=store, pearl=store2, mode=detect.Mode.FRESH_COPY)
+        assert d2.is_noop is False
+
+    def test_discovery_rejects_inconsistent_invariants(self, tmp_path: Path) -> None:
+        """Same root + non-NOOP, or different roots + NOOP, both refused."""
+        store = detect.OperateStore(root=tmp_path.resolve())
+        store2 = detect.OperateStore(root=(tmp_path / "other").resolve())
+        with pytest.raises(ValueError, match="expected Mode.NOOP"):
+            detect.Discovery(quickstart=store, pearl=store, mode=detect.Mode.MERGE)
+        with pytest.raises(ValueError, match="different roots"):
+            detect.Discovery(quickstart=store, pearl=store2, mode=detect.Mode.NOOP)
+
+    def test_operate_store_post_init_resolves_relative_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`__post_init__` must turn a relative `root` into an absolute one."""
+        monkeypatch.chdir(tmp_path)
+        rel = Path("relstore")
+        rel.mkdir()
+        store = detect.OperateStore(root=rel)
+        assert store.root.is_absolute()
+        assert store.root == (tmp_path / "relstore").resolve()
+
+    def test_operate_store_post_init_emits_info_when_symlink_resolves(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When `Path.resolve()` changes the path (e.g. symlink), `__post_init__`
+        must emit an informational message naming both paths so subsequent
+        log lines / error messages aren't referring to a path the user
+        doesn't recognise. Locks the user-visible message contract."""
+        real = tmp_path / "real_store"
+        real.mkdir()
+        link = tmp_path / "link_store"
+        link.symlink_to(real)
+        store = detect.OperateStore(root=link)
+        assert store.root == real.resolve()
+        out = capsys.readouterr().out
+        assert "Resolved store root" in out
+        assert str(link) in out
+        assert str(real.resolve()) in out
+
+    def test_operate_store_post_init_resolve_failure_becomes_value_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """OSError from Path.resolve() should become a clean ValueError."""
+        def boom(self: Path, *, strict: bool = False) -> Path:
+            raise OSError("permission denied: '/some/parent'")
+        monkeypatch.setattr(Path, "resolve", boom)
+        with pytest.raises(ValueError, match="Cannot resolve store root"):
+            detect.OperateStore(root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# filesystem.py — extras
+# ---------------------------------------------------------------------------
+
+class TestFilesystemExtras:
+    def test_rename_source_for_rollback(self, tmp_path: Path) -> None:
+        src_root = tmp_path / ".operate"
+        src_root.mkdir()
+        store = detect.OperateStore(root=src_root)
+        new = filesystem.rename_source_for_rollback(store)
+        assert new.exists()
+        assert not src_root.exists()
+        assert ".operate.migrated.bak." in new.name
+
+    def test_fix_root_ownership_no_services_dir(self, tmp_path: Path) -> None:
+        store = detect.OperateStore(root=tmp_path)
+        # Should be a no-op, no exceptions.
+        filesystem.fix_root_ownership(store)
+
+    def test_fix_root_ownership_no_root_owned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "services" / "sc-aaa" / "persistent_data").mkdir(parents=True)
+        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: False)
+        called: list[Any] = []
+        monkeypatch.setattr(filesystem.subprocess, "run",
+                            lambda *a, **k: called.append((a, k)))
+        store = detect.OperateStore(root=tmp_path)
+        filesystem.fix_root_ownership(store)
+        assert called == []
+
+    def test_fix_root_ownership_runs_chown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pdata = tmp_path / "services" / "sc-aaa" / "persistent_data"
+        pdata.mkdir(parents=True)
+        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: True)
+        invoked: list[list[str]] = []
+        def fake_run(cmd: list[str], **kw: Any) -> Any:
+            invoked.append(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+        monkeypatch.setattr(filesystem.subprocess, "run", fake_run)
+        store = detect.OperateStore(root=tmp_path)
+        filesystem.fix_root_ownership(store)
+        assert invoked and "chown" in invoked[0]
+
+    def test_fix_root_ownership_chown_failure_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pdata = tmp_path / "services" / "sc-aaa" / "persistent_data"
+        pdata.mkdir(parents=True)
+        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: True)
+        def fake_run(cmd: list[str], **kw: Any) -> Any:
+            raise subprocess.CalledProcessError(1, cmd)
+        monkeypatch.setattr(filesystem.subprocess, "run", fake_run)
+        store = detect.OperateStore(root=tmp_path.resolve())
+        # Must raise — caller would otherwise corrupt the destination.
+        with pytest.raises(RuntimeError, match="could not chown"):
+            filesystem.fix_root_ownership(store)
+
+    def test_fix_root_ownership_refuses_outside_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Construct a service dir that is symlinked OUTSIDE the store.
+        store_root = tmp_path / "store"
+        store_root.mkdir()
+        (store_root / "services").mkdir()
+        outside = tmp_path / "elsewhere/persistent_data"
+        outside.mkdir(parents=True)
+        # Service dir contains a symlink to the outside persistent_data.
+        sdir = store_root / "services" / "sc-aaa"
+        sdir.mkdir()
+        (sdir / "persistent_data").symlink_to(outside)
+        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: True)
+        store = detect.OperateStore(root=store_root.resolve())
+        with pytest.raises(RuntimeError, match="not inside store root"):
+            filesystem.fix_root_ownership(store)
+
+    def test_merge_service_missing_source_key_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing agent key MUST raise `MissingAgentKey` (an OSError
+        subclass) so `_run_mode_b`'s existing OSError catch aggregates
+        it into `MigrationOutcome.unmigratable`. A silent skip would
+        leave the user with an unstartable service after on-chain ops
+        have committed."""
+        src_root = tmp_path / "src/.operate"
+        _write_service(src_root, "sc-aaa", agent_addresses=["0xmissing"])
+        # Note: no key file written.
+        src = detect.OperateStore(root=src_root.resolve())
+        dest_root = tmp_path / "dest/.operate"
+        dest_root.mkdir(parents=True)
+        dest = detect.OperateStore(root=dest_root.resolve())
+        svc = _fake_service(
+            "sc-aaa",
+            agent_addresses=["0xmissing"],
+            path=(src_root / "services" / "sc-aaa").resolve(),
+        )
+        with pytest.raises(filesystem.MissingAgentKey, match="0xmissing"):
+            filesystem.merge_service(svc, src, dest)
+        # MissingAgentKey IS-A OSError so the orchestrator's catch
+        # handles it generically.
+        try:
+            filesystem.merge_service(svc, src, dest)
+        except OSError:
+            pass
+        else:
+            pytest.fail("MissingAgentKey must be an OSError subclass")
+
+
+# ---------------------------------------------------------------------------
+# prompts.py — extras
+# ---------------------------------------------------------------------------
+
+class TestPromptsExtras:
+    def test_password_attended_uses_getpass(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Middleware's `ask_or_get_from_env` calls getpass.getpass directly
+        # when ATTENDED=true regardless of isatty.
+        monkeypatch.setenv("ATTENDED", "true")
+        import getpass
+        monkeypatch.setattr(getpass, "getpass", lambda prompt: "secret")
+        assert prompts.password("pw: ") == "secret"
+
+    def test_password_unattended_reads_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ATTENDED", "false")
+        monkeypatch.setenv("OPERATE_PASSWORD", "from-env")
+        assert prompts.password("pw: ") == "from-env"
+
+    def test_password_unattended_missing_env_returns_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # raise_if_missing=False in our wrapper -> returns empty string when
+        # the env var is unset in unattended mode.
+        monkeypatch.setenv("ATTENDED", "false")
+        monkeypatch.delenv("OPERATE_PASSWORD", raising=False)
+        assert prompts.password("pw: ") == ""
+
+    def test_collision_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "1")
+        choice = prompts.collision(target=Path("/x"), kind="service")
+        assert choice == prompts.CollisionChoice.SKIP
+
+    def test_collision_overwrite(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "2")
+        choice = prompts.collision(target=Path("/x"), kind="service")
+        assert choice == prompts.CollisionChoice.OVERWRITE_WITH_BACKUP
+
+    def test_collision_retries_on_garbage(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        answers = iter(["", "??", "2"])
+        monkeypatch.setattr("builtins.input", lambda _: next(answers))
+        choice = prompts.collision(target=Path("/x"), kind="key")
+        assert choice == prompts.CollisionChoice.OVERWRITE_WITH_BACKUP
+
+    def test_info_warn_print(self, capsys: pytest.CaptureFixture[str]) -> None:
+        prompts.info("hello")
+        prompts.warn("uhoh")
+        out = capsys.readouterr().out
+        assert "hello" in out and "uhoh" in out
+
+    def test_fatal_exits_with_code(self) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            prompts.fatal("bad", code=7)
+        assert excinfo.value.code == 7
+
+    def test_backup_suffix_format(self) -> None:
+        s = prompts.backup_suffix()
+        assert s.startswith("bak.")
+        assert s[len("bak."):].isdigit()
+
+    def test_ask_password_prompts_warning_message(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Failures should print the warning, including the "remaining" path.
+        answers = iter(["w1", "w2"])
+        monkeypatch.setattr(prompts, "password", lambda _: next(answers))
+        result = prompts.ask_password_validating(
+            prompt="pw: ", validate=lambda _: False, attempts=2,
+        )
+        assert result is None
+        captured = capsys.readouterr().out
+        assert "Wrong password" in captured
+
+
+# ---------------------------------------------------------------------------
+# stop.py
+# ---------------------------------------------------------------------------
+
+class TestStop:
+    def test_stop_via_middleware_calls_into_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import stop
+
+        called: dict[str, Any] = {}
+        fake_quickstart = types.ModuleType("operate.quickstart")
+        fake_stop = types.ModuleType("operate.quickstart.stop_service")
+        def fake_stop_service(operate: Any, config_path: str) -> None:
+            called["operate"] = operate
+            called["config_path"] = config_path
+        fake_stop.stop_service = fake_stop_service  # type: ignore[attr-defined]
+        operate_pkg = sys.modules.get("operate") or types.ModuleType("operate")
+        monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+        monkeypatch.setitem(sys.modules, "operate.quickstart", fake_quickstart)
+        monkeypatch.setitem(
+            sys.modules, "operate.quickstart.stop_service", fake_stop,
+        )
+
+        stop.stop_via_middleware(operate="OP", config_path="cfg.json")
+        assert called == {"operate": "OP", "config_path": "cfg.json"}
+
+    def test_force_remove_known_containers_no_leftovers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import stop
+        monkeypatch.setattr(stop, "docker_quickstart_containers", lambda: [])
+        assert stop.force_remove_known_containers() == []
+
+    def test_force_remove_known_containers_removes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import stop
+        monkeypatch.setattr(stop, "docker_quickstart_containers", lambda: ["abci0"])
+        invoked: list[list[str]] = []
+        monkeypatch.setattr(stop.subprocess, "run",
+                            lambda cmd, **kw: invoked.append(cmd))
+        result = stop.force_remove_known_containers()
+        assert result == ["abci0"]
+        assert invoked and "rm" in invoked[0]
+
+    def test_force_remove_known_containers_handles_missing_docker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import stop
+        monkeypatch.setattr(stop, "docker_quickstart_containers", lambda: ["abci0"])
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise FileNotFoundError("nope")
+        monkeypatch.setattr(stop.subprocess, "run", boom)
+        assert stop.force_remove_known_containers() == []
+
+
+# ---------------------------------------------------------------------------
+# transfer.py
+# ---------------------------------------------------------------------------
+
+class TestTransfer:
+    def test_transfer_service_nft_encodes_and_dispatches(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import transfer
+
+        encoded: dict[str, Any] = {}
+        instance = types.SimpleNamespace(
+            encode_abi=lambda abi_element_identifier, args: (
+                encoded.update(name=abi_element_identifier, args=args) or "0xdeadbeef"
+            ),
+        )
+        registry = types.SimpleNamespace(
+            service_registry=types.SimpleNamespace(
+                get_instance=lambda **kw: instance,
+            ),
+        )
+        _install_fake_autonomy(monkeypatch, registry)
+
+        sent: dict[str, Any] = {}
+        operate_pkg = types.ModuleType("operate")
+        operate_utils = types.ModuleType("operate.utils")
+        operate_gnosis = types.ModuleType("operate.utils.gnosis")
+        def fake_send(txd: bytes, safe: str, ledger_api: Any, crypto: Any, to: str) -> str:
+            sent.update(txd=txd, safe=safe, to=to)
+            return "0xtxhash"
+        operate_gnosis.send_safe_txs = fake_send  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+        monkeypatch.setitem(sys.modules, "operate.utils", operate_utils)
+        monkeypatch.setitem(sys.modules, "operate.utils.gnosis", operate_gnosis)
+
+        result = transfer.transfer_service_nft(
+            ledger_api=object(),
+            crypto=object(),
+            service_registry_address="0xreg",
+            qs_master_safe="0xqs",
+            pearl_master_safe="0xpl",
+            service_id=99,
+        )
+        assert result == "0xtxhash"
+        # `transferFrom`, NOT `safeTransferFrom` — see transfer.py docstring.
+        # A regression to safeTransferFrom would silently revert on Safes
+        # without `CompatibilityFallbackHandler` (no `onERC721Received`).
+        assert encoded == {"name": "transferFrom", "args": ["0xqs", "0xpl", 99]}
+        assert sent["safe"] == "0xqs"
+        assert sent["to"] == "0xreg"
+        assert sent["txd"] == bytes.fromhex("deadbeef")
+
+    def test_swap_service_safe_owner_delegates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import transfer
+
+        captured: dict[str, Any] = {}
+        operate_pkg = types.ModuleType("operate")
+        operate_utils = types.ModuleType("operate.utils")
+        operate_gnosis = types.ModuleType("operate.utils.gnosis")
+        def fake_swap(**kw: Any) -> None:
+            captured.update(kw)
+        operate_gnosis.swap_owner = fake_swap  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+        monkeypatch.setitem(sys.modules, "operate.utils", operate_utils)
+        monkeypatch.setitem(sys.modules, "operate.utils.gnosis", operate_gnosis)
+
+        transfer.swap_service_safe_owner(
+            ledger_api="LA", crypto="CR",
+            service_safe="0xs", old_owner="0xo", new_owner="0xn",
+        )
+        assert captured == {
+            "ledger_api": "LA", "crypto": "CR",
+            "safe": "0xs", "old_owner": "0xo", "new_owner": "0xn",
+        }
+
+
+# ---------------------------------------------------------------------------
+# migrate_to_pearl.py — orchestrator
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def orch(monkeypatch: pytest.MonkeyPatch):
+    """Fresh import of the orchestrator with `operate.*` stubs in place.
+
+    The orchestrator's lazy `from operate...` imports are resolved by these
+    stubs, so tests can run without the real middleware installed.
+    """
+    # Stub operate.cli.OperateApp + operate.operate_types + operate.ledger.profiles.
+    operate_pkg = types.ModuleType("operate")
+    operate_cli = types.ModuleType("operate.cli")
+    operate_types = types.ModuleType("operate.operate_types")
+    operate_ledger_pkg = types.ModuleType("operate.ledger")
+    operate_ledger_profiles = types.ModuleType("operate.ledger.profiles")
+
+    class FakeChain:
+        GNOSIS = None  # filled in below
+        def __init__(self, value: str) -> None:
+            self.value = value
+            self.name = value.upper()
+        def __eq__(self, other: object) -> bool:
+            return isinstance(other, FakeChain) and self.value == other.value
+        def __hash__(self) -> int:
+            return hash(self.value)
+
+    FakeChain.GNOSIS = FakeChain("gnosis")  # type: ignore[assignment]
+    FakeChain.OPTIMISM = FakeChain("optimism")  # type: ignore[attr-defined]
+
+    class FakeOnChainState:
+        PRE_REGISTRATION = types.SimpleNamespace(name="PRE_REGISTRATION")
+        DEPLOYED = types.SimpleNamespace(name="DEPLOYED")
+
+    class FakeLedgerType:
+        ETHEREUM = "ethereum"
+
+    operate_types.Chain = FakeChain  # type: ignore[attr-defined]
+    operate_types.OnChainState = FakeOnChainState  # type: ignore[attr-defined]
+    operate_types.LedgerType = FakeLedgerType  # type: ignore[attr-defined]
+    operate_ledger_profiles.CONTRACTS = {  # type: ignore[attr-defined]
+        FakeChain.GNOSIS: {"service_registry": "0xreg"},
+        FakeChain.OPTIMISM: {"service_registry": "0xreg-o"},
+    }
+    # OperateApp constructor is replaced per-test via _load_wallet patch below.
+    operate_cli.OperateApp = lambda **kw: types.SimpleNamespace()  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+    monkeypatch.setitem(sys.modules, "operate.cli", operate_cli)
+    monkeypatch.setitem(sys.modules, "operate.operate_types", operate_types)
+    monkeypatch.setitem(sys.modules, "operate.ledger", operate_ledger_pkg)
+    monkeypatch.setitem(sys.modules, "operate.ledger.profiles", operate_ledger_profiles)
+
+    # Force a fresh import so any cached imports pick up the stubs.
+    # `from scripts.pearl_migration import migrate_to_pearl` returns the
+    # parent package's cached attribute even after `sys.modules.pop`, so
+    # we also delete the attribute on the package object before
+    # importing — otherwise a previous test's `m` (with stale Chain
+    # binding) silently leaks into this test.
+    import scripts.pearl_migration as _pkg
+    sys.modules.pop("scripts.pearl_migration.migrate_to_pearl", None)
+    if hasattr(_pkg, "migrate_to_pearl"):
+        delattr(_pkg, "migrate_to_pearl")
+    from scripts.pearl_migration import migrate_to_pearl as m
+    return m, FakeChain, FakeOnChainState
+
+
+class TestParseArgs:
+    def test_help(self, orch: Any) -> None:
+        m, *_ = orch
+        with pytest.raises(SystemExit):
+            m._parse_args(["--help"])
+
+    def test_defaults(self, orch: Any) -> None:
+        m, *_ = orch
+        ns = m._parse_args([])
+        assert ns.config_path is None
+        assert ns.dry_run is False
+
+
+class TestSelectServices:
+    def test_no_services_aborts(self, orch: Any, tmp_path: Path) -> None:
+        m, *_ = orch
+        store = detect.OperateStore(root=tmp_path)
+        with pytest.raises(SystemExit):
+            m._select_services(store, None)
+
+    def test_single_service_auto_selected(
+        self, orch: Any, tmp_path: Path, patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="A")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = (
+            _fake_service("sc-aaa", name="A")
+        )
+        store = detect.OperateStore(root=tmp_path)
+        sel = m._select_services(store, None)
+        assert [s.service_config_id for s in sel] == ["sc-aaa"]
+
+    def test_multi_service_picks_one(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="A")
+        _write_service(tmp_path, "sc-bbb", name="B")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = _fake_service("sc-aaa", name="A")
+        patch_service_load[(tmp_path / "services/sc-bbb").resolve()] = _fake_service("sc-bbb", name="B")
+        store = detect.OperateStore(root=tmp_path)
+        monkeypatch.setattr("builtins.input", lambda _: "2")
+        sel = m._select_services(store, None)
+        assert [s.service_config_id for s in sel] == ["sc-bbb"]
+
+    def test_multi_service_picks_all(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="A")
+        _write_service(tmp_path, "sc-bbb", name="B")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = _fake_service("sc-aaa", name="A")
+        patch_service_load[(tmp_path / "services/sc-bbb").resolve()] = _fake_service("sc-bbb", name="B")
+        store = detect.OperateStore(root=tmp_path)
+        monkeypatch.setattr("builtins.input", lambda _: "3")
+        sel = m._select_services(store, None)
+        assert [s.service_config_id for s in sel] == ["sc-aaa", "sc-bbb"]
+
+    def test_multi_service_retries_on_bad_input(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="A")
+        _write_service(tmp_path, "sc-bbb", name="B")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = _fake_service("sc-aaa", name="A")
+        patch_service_load[(tmp_path / "services/sc-bbb").resolve()] = _fake_service("sc-bbb", name="B")
+        store = detect.OperateStore(root=tmp_path)
+        answers = iter(["foo", "9", "1"])
+        monkeypatch.setattr("builtins.input", lambda _: next(answers))
+        sel = m._select_services(store, None)
+        assert [s.service_config_id for s in sel] == ["sc-aaa"]
+
+    def test_multi_service_eof_on_stdin_aborts_cleanly(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        patch_service_load: dict[Path, Any],
+    ) -> None:
+        """Closed/piped stdin (CI, automation) must NOT spin in `input()`
+        forever. Surface as a `fatal()` (sys.exit) instead of an
+        EOFError traceback."""
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="A")
+        _write_service(tmp_path, "sc-bbb", name="B")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = _fake_service("sc-aaa", name="A")
+        patch_service_load[(tmp_path / "services/sc-bbb").resolve()] = _fake_service("sc-bbb", name="B")
+        store = detect.OperateStore(root=tmp_path)
+        def boom_input(_: str) -> str:
+            raise EOFError
+        monkeypatch.setattr("builtins.input", boom_input)
+        with pytest.raises(SystemExit):
+            m._select_services(store, None)
+
+    def test_config_path_matches_by_name(
+        self, orch: Any, tmp_path: Path, patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="Trader Agent")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = (
+            _fake_service("sc-aaa", name="Trader Agent")
+        )
+        cfg = tmp_path / "cfg.json"
+        cfg.write_text(json.dumps({"name": "Trader Agent"}))
+        store = detect.OperateStore(root=tmp_path)
+        sel = m._select_services(store, str(cfg))
+        assert [s.service_config_id for s in sel] == ["sc-aaa"]
+
+    def test_config_path_matches_by_hash(
+        self, orch: Any, tmp_path: Path, patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        # Different name in service config — match by hash instead.
+        sdir = tmp_path / "services" / "sc-aaa"
+        sdir.mkdir(parents=True)
+        (sdir / "config.json").write_text(json.dumps({
+            "name": "Different Name",
+            "agent_addresses": [],
+            "hash": "bafy-test",
+        }))
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = (
+            _fake_service("sc-aaa", name="Different Name", hash_="bafy-test")
+        )
+        cfg = tmp_path / "cfg.json"
+        cfg.write_text(json.dumps({"name": "Trader Agent", "hash": "bafy-test"}))
+        store = detect.OperateStore(root=tmp_path)
+        sel = m._select_services(store, str(cfg))
+        assert [s.service_config_id for s in sel] == ["sc-aaa"]
+
+    def test_config_path_no_match_aborts(
+        self, orch: Any, tmp_path: Path, patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="A")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = (
+            _fake_service("sc-aaa", name="A", hash_="bafy-test")
+        )
+        cfg = tmp_path / "cfg.json"
+        cfg.write_text(json.dumps({"name": "Z", "hash": "h"}))
+        store = detect.OperateStore(root=tmp_path)
+        with pytest.raises(SystemExit):
+            m._select_services(store, str(cfg))
+
+    def test_config_path_unreadable_aborts(
+        self, orch: Any, tmp_path: Path, patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        _write_service(tmp_path, "sc-aaa", name="A")
+        patch_service_load[(tmp_path / "services/sc-aaa").resolve()] = (
+            _fake_service("sc-aaa", name="A")
+        )
+        store = detect.OperateStore(root=tmp_path)
+        with pytest.raises(SystemExit):
+            m._select_services(store, str(tmp_path / "missing.json"))
+
+
+class TestPreflight:
+    def test_noop_exits(self, orch: Any, tmp_path: Path) -> None:
+        m, *_ = orch
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=tmp_path),
+            pearl=detect.OperateStore(root=tmp_path),
+            mode=detect.Mode.NOOP,
+        )
+        with pytest.raises(SystemExit) as excinfo:
+            m._preflight(d)
+        assert excinfo.value.code == 0
+
+    def test_pearl_running_aborts(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, *_ = orch
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=tmp_path / "qs"),
+            pearl=detect.OperateStore(root=tmp_path / "pl"),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        monkeypatch.setattr(m, "pearl_daemon_running", lambda: True)
+        with pytest.raises(SystemExit):
+            m._preflight(d)
+
+    def test_with_leftover_containers_warns(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        m, *_ = orch
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=tmp_path / "qs"),
+            pearl=detect.OperateStore(root=tmp_path / "pl"),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        monkeypatch.setattr(m, "pearl_daemon_running", lambda: False)
+        monkeypatch.setattr(m, "docker_quickstart_containers", lambda: ["abci0"])
+        m._preflight(d)
+        assert "abci0" in capsys.readouterr().out
+
+
+class TestLoadWallet:
+    def test_no_wallet_aborts(self, orch: Any, tmp_path: Path) -> None:
+        m, *_ = orch
+        store = detect.OperateStore(root=tmp_path)
+        with pytest.raises(SystemExit):
+            m._load_wallet(store, "label")
+
+    @staticmethod
+    def _stub_master_wallet_manager(
+        monkeypatch: pytest.MonkeyPatch, *, valid_password: Optional[str] = None,
+    ) -> list[str]:
+        """Replace `MasterWalletManager` so `is_password_valid` is observable
+        and the constructor never touches disk. Returns the list it appends to."""
+        seen: list[str] = []
+
+        class FakeMWM:
+            def __init__(self, path: Path) -> None:
+                self.path = path
+
+            def is_password_valid(self, pw: str) -> bool:
+                seen.append(pw)
+                return valid_password is not None and pw == valid_password
+
+        operate_pkg = sys.modules.setdefault("operate", types.ModuleType("operate"))
+        operate_wallet = sys.modules.setdefault(
+            "operate.wallet", types.ModuleType("operate.wallet"),
+        )
+        fake_master = types.ModuleType("operate.wallet.master")
+        fake_master.MasterWalletManager = FakeMWM  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate", operate_pkg)
+        monkeypatch.setitem(sys.modules, "operate.wallet", operate_wallet)
+        monkeypatch.setitem(sys.modules, "operate.wallet.master", fake_master)
+        return seen
+
+    def test_password_failure_aborts_without_building_app(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Wrong password: validator runs but OperateApp is never built."""
+        m, *_ = orch
+        _write_wallet(tmp_path)
+        store = detect.OperateStore(root=tmp_path)
+
+        self._stub_master_wallet_manager(monkeypatch, valid_password=None)
+        # OperateApp should never be constructed on a bad password.
+        operate_app_calls = []
+        operate_cli = sys.modules.setdefault("operate.cli", types.ModuleType("operate.cli"))
+        operate_cli.OperateApp = lambda **kw: operate_app_calls.append(kw) or types.SimpleNamespace()  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate.cli", operate_cli)
+
+        monkeypatch.setattr(m, "ask_password_validating", lambda **kw: None)
+        with pytest.raises(SystemExit):
+            m._load_wallet(store, "label")
+        assert operate_app_calls == [], (
+            "OperateApp must NOT be built when password validation fails — "
+            "would otherwise mutate Pearl's .operate (migrations + version backup)."
+        )
+
+    def test_happy_path_validates_then_builds_app(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, *_ = orch
+        _write_wallet(tmp_path)
+        store = detect.OperateStore(root=tmp_path)
+
+        seen = self._stub_master_wallet_manager(monkeypatch, valid_password="thepw")
+
+        fake_wallet = types.SimpleNamespace(name="loaded")
+        fake_wm = types.SimpleNamespace(load=lambda lt: fake_wallet)
+        fake_app = types.SimpleNamespace(wallet_manager=fake_wm, password=None)
+        operate_cli = sys.modules.setdefault("operate.cli", types.ModuleType("operate.cli"))
+        operate_cli.OperateApp = lambda **kw: fake_app  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate.cli", operate_cli)
+
+        # `ask_password_validating` exercises the validate callable.
+        def fake_ask(prompt: str, validate, **kw: Any) -> str:
+            assert validate("wrong") is False
+            assert validate("thepw") is True
+            return "thepw"
+        monkeypatch.setattr(m, "ask_password_validating", fake_ask)
+
+        app, wallet = m._load_wallet(store, "label")
+        assert wallet is fake_wallet
+        assert app.password == "thepw"
+        assert seen == ["wrong", "thepw"]
+
+
+class TestRunModeA:
+    def test_dry_run_with_existing_pearl(
+        self, orch: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        outcome = m._run_mode_a(disc=d, dry_run=True)
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        assert pl_root.exists()  # not actually moved
+        # Mode A always returns an empty (is_complete) outcome — guards the
+        # uniform-MigrationOutcome contract documented on _run_mode_a.
+        assert outcome.is_complete is True
+        assert outcome.unmigratable == ()
+        assert outcome.drain_failures == ()
+
+    def test_real_run_copies_and_renames(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        _write_service(qs_root, "sc-aaa", agent_addresses=["0xa"])
+        _write_key(qs_root, "0xa")
+        _write_wallet(qs_root)
+        pl_root = tmp_path / "pl/.operate"
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root.resolve()),
+            pearl=detect.OperateStore(root=pl_root.resolve()),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: ["abci0"])
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        outcome = m._run_mode_a(disc=d, dry_run=False)
+        assert (pl_root / "wallets" / "ethereum.json").exists()
+        # Source has been renamed away.
+        assert not qs_root.exists()
+        assert outcome.is_complete is True
+
+    def test_dry_run_with_existing_pearl_backup_print(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # Cover the "[dry-run] would back up" branch by ensuring pearl exists.
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        m._run_mode_a(disc=d, dry_run=True)
+        assert "Would back up" in capsys.readouterr().out
+
+    def test_force_cleanup_failure_is_fatal_in_mode_a(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mode A has no per-service aggregation: an unstoppable
+        deployment MUST be `fatal()`, not silently proceed to copy a
+        live `.operate/`."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        _write_service(qs_root, "sc-aaa", agent_addresses=["0xa"])
+        _write_key(qs_root, "0xa")
+        _write_wallet(qs_root)
+        pl_root = tmp_path / "pl/.operate"
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root.resolve()),
+            pearl=detect.OperateStore(root=pl_root.resolve()),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        def boom() -> list:
+            raise subprocess.TimeoutExpired(cmd=["docker", "rm"], timeout=30)
+        monkeypatch.setattr(m, "force_remove_known_containers", boom)
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        with pytest.raises(SystemExit):
+            m._run_mode_a(disc=d, dry_run=False)
+
+    def test_real_run_backs_up_existing_empty_pearl(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Covers the non-dry-run branch where Pearl dir exists but has no wallet."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        _write_service(qs_root, "sc-aaa", agent_addresses=["0xa"])
+        _write_key(qs_root, "0xa")
+        _write_wallet(qs_root)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)  # exists but empty (no wallet)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root.resolve()),
+            pearl=detect.OperateStore(root=pl_root.resolve()),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        m._run_mode_a(disc=d, dry_run=False)
+        out = capsys.readouterr().out
+        assert "Backed up empty Pearl dir" in out
+        assert (pl_root / "wallets" / "ethereum.json").exists()
+        # Backup sibling exists
+        siblings = list((tmp_path / "pl").iterdir())
+        assert any(".bak." in p.name for p in siblings)
+
+
+class TestStepTerminate:
+    """Direct unit tests for `_step_terminate` — narrows the test surface
+    so a step-helper signature regression is caught locally rather than
+    only when the whole `_migrate_one_service` is exercised."""
+
+    def _manager(
+        self, FakeOnChainState: Any, *, state_seq: list, terminate=None,
+    ) -> Any:
+        states = list(state_seq)
+        return types.SimpleNamespace(
+            terminate_service_on_chain_from_safe=(
+                terminate or (lambda **kw: None)
+            ),
+            _get_on_chain_state=lambda s, c: states.pop(0) if states else FakeOnChainState.PRE_REGISTRATION,
+        )
+
+    def test_skip_when_already_pre_registration(
+        self, orch: Any,
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        signed = {"n": 0}
+        manager = self._manager(
+            FakeOnChainState, state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        m._step_terminate(
+            manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: signed.update(n=signed["n"] + 1),
+            on_chain_state_cls=FakeOnChainState,
+        )
+        assert signed["n"] == 0   # never signed because already there
+
+    def test_success_path_signs_and_advances_state(
+        self, orch: Any,
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        signed = {"n": 0}
+        manager = self._manager(
+            FakeOnChainState,
+            state_seq=[FakeOnChainState.DEPLOYED, FakeOnChainState.PRE_REGISTRATION],
+        )
+        m._step_terminate(
+            manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: signed.update(n=signed["n"] + 1),
+            on_chain_state_cls=FakeOnChainState,
+        )
+        assert signed["n"] == 1   # ensure_signable was called
+
+    def test_terminate_raise_wraps_into_unmigratable(self, orch: Any) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        def boom(**kw: Any) -> None:
+            raise RuntimeError("revert: NotEnoughFunds")
+        manager = self._manager(
+            FakeOnChainState, state_seq=[FakeOnChainState.DEPLOYED],
+            terminate=boom,
+        )
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_terminate(
+                manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+            )
+        assert "could not unstake/terminate" in ei.value.reason
+
+    def test_post_terminate_state_read_failure_wraps(self, orch: Any) -> None:
+        """Terminate succeeded but the verification RPC raises. Without the
+        wrap, the raw exception propagates past `_run_mode_b`'s narrow
+        `except _Unmigratable` and aborts the entire batch with on-chain
+        state already advanced. The fix converts it to a per-service
+        `_Unmigratable` so the next re-run resumes from the next step."""
+        m, FakeChain, FakeOnChainState = orch
+        calls = {"n": 0}
+        def states(s: Any, c: str) -> Any:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return FakeOnChainState.DEPLOYED  # before terminate
+            raise ConnectionError("rpc 502")  # post-terminate read fails
+        manager = types.SimpleNamespace(
+            terminate_service_on_chain_from_safe=lambda **kw: None,
+            _get_on_chain_state=states,
+        )
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_terminate(
+                manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+            )
+        assert "post-state verification" in ei.value.reason
+        assert "rpc 502" in ei.value.reason
+
+    def test_state_unchanged_after_terminate_raises(self, orch: Any) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        manager = self._manager(
+            FakeOnChainState,
+            # before=DEPLOYED, after-terminate also DEPLOYED → invariant broken.
+            state_seq=[FakeOnChainState.DEPLOYED, FakeOnChainState.DEPLOYED],
+        )
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_terminate(
+                manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+            )
+        assert "expected PRE_REGISTRATION" in ei.value.reason
+
+    @pytest.mark.parametrize("bug_cls", [
+        TypeError, AttributeError, NameError, ImportError,
+    ])
+    def test_programming_bug_propagates_not_wrapped(
+        self, orch: Any, bug_cls: type,
+    ) -> None:
+        """Step exception wrapper must NOT swallow programming bugs as
+        'chain failed'. Covers every member of `_PROGRAMMING_BUGS`."""
+        m, FakeChain, FakeOnChainState = orch
+        def buggy(**kw: Any) -> None:
+            raise bug_cls("simulated programming bug")
+        manager = self._manager(
+            FakeOnChainState, state_seq=[FakeOnChainState.DEPLOYED],
+            terminate=buggy,
+        )
+        with pytest.raises(bug_cls):
+            m._step_terminate(
+                manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+            )
+
+    @pytest.mark.parametrize("rpc_cls", [
+        KeyError,           # web3 / middleware: missing chain metadata
+        LookupError,        # eth_abi / contract attribute resolution
+        RuntimeError,       # generic chain-side
+        ConnectionError,    # transport-layer
+    ])
+    def test_legitimate_rpc_failures_get_wrapped_not_re_raised(
+        self, orch: Any, rpc_cls: type,
+    ) -> None:
+        """Regression guard: KeyError / LookupError MUST become per-service
+        `_Unmigratable`, not crash the whole batch. Round 4 specifically
+        removed these from `_PROGRAMMING_BUGS` for this reason; this test
+        prevents a future re-widening from regressing the contract."""
+        m, FakeChain, FakeOnChainState = orch
+        def chain_failure(**kw: Any) -> None:
+            raise rpc_cls("simulated chain-side failure")
+        manager = self._manager(
+            FakeOnChainState, state_seq=[FakeOnChainState.DEPLOYED],
+            terminate=chain_failure,
+        )
+        with pytest.raises(m._Unmigratable):
+            m._step_terminate(
+                manager=manager, service=object(), sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None, on_chain_state_cls=FakeOnChainState,
+            )
+
+
+class TestStepTransferNft:
+    """Direct unit tests for `_step_transfer_nft` — covers the idempotent
+    skip branch (NFT already on Pearl), the unreadable-owner branch (RPC
+    error → None), the third-party-owner branch, the success path, and
+    the wrap-on-failure branch."""
+
+    @pytest.fixture
+    def fake_transfer(self, monkeypatch: pytest.MonkeyPatch):  # noqa: ANN201
+        """Install a stub transfer module; return the call recorder."""
+        calls: list = []
+        def fake_nft(**kw: Any) -> str:
+            calls.append(kw); return "0x1"
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.transfer_service_nft = fake_nft  # type: ignore[attr-defined]
+        fake_mod.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        return calls
+
+    def test_skip_when_nft_already_on_pearl(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_transfer: list,
+    ) -> None:
+        m, *_ = orch
+        signed = {"n": 0}
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
+        m._step_transfer_nft(
+            ledger_api="LA",
+            qs_wallet=types.SimpleNamespace(crypto="CR"),
+            registry_addr="0xreg",
+            qs_master_safe="0xqs", pearl_master_safe="0xpl",
+            token_id=42, sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: signed.update(n=signed["n"] + 1),
+        )
+        assert fake_transfer == []
+        assert signed["n"] == 0
+
+    def test_owner_unreadable_raises(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_transfer: list,
+    ) -> None:
+        m, *_ = orch
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: None)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_transfer_nft(
+                ledger_api="LA",
+                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                registry_addr="0xreg",
+                qs_master_safe="0xqs", pearl_master_safe="0xpl",
+                token_id=42, sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        assert "could not read NFT owner" in ei.value.reason
+
+    def test_owner_third_party_raises(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_transfer: list,
+    ) -> None:
+        m, *_ = orch
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xstranger")
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_transfer_nft(
+                ledger_api="LA",
+                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                registry_addr="0xreg",
+                qs_master_safe="0xqs", pearl_master_safe="0xpl",
+                token_id=42, sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        assert "expected quickstart" in ei.value.reason
+
+    def test_success_path_calls_transfer_then_signs(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_transfer: list,
+    ) -> None:
+        m, *_ = orch
+        signed = {"n": 0}
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        m._step_transfer_nft(
+            ledger_api="LA",
+            qs_wallet=types.SimpleNamespace(crypto="CR"),
+            registry_addr="0xreg",
+            qs_master_safe="0xqs", pearl_master_safe="0xpl",
+            token_id=42, sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: signed.update(n=signed["n"] + 1),
+        )
+        assert signed["n"] == 1
+        assert len(fake_transfer) == 1
+        assert fake_transfer[0]["service_id"] == 42
+
+    def test_transfer_failure_wraps_into_unmigratable(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        m, *_ = orch
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        def boom(**kw: Any) -> None:
+            raise RuntimeError("nonce stale")
+        fake_mod.transfer_service_nft = boom  # type: ignore[attr-defined]
+        fake_mod.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_transfer_nft(
+                ledger_api="LA",
+                qs_wallet=types.SimpleNamespace(crypto="CR"),
+                registry_addr="0xreg",
+                qs_master_safe="0xqs", pearl_master_safe="0xpl",
+                token_id=42, sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        assert "NFT transfer failed" in ei.value.reason
+
+
+class TestStepSwapServiceSafeOwner:
+    """Direct unit tests for `_step_swap_service_safe_owner` — covers
+    already-swapped skip, owners-unreadable wrap, qs-not-an-owner refuse,
+    success path, and the half-state error message after swap failure."""
+
+    @pytest.fixture
+    def fake_swap(self, monkeypatch: pytest.MonkeyPatch):  # noqa: ANN201
+        calls: list = []
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
+        def fake(**kw: Any) -> None:
+            calls.append(kw)
+        fake_mod.swap_service_safe_owner = fake  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        return calls
+
+    def test_skip_when_already_swapped(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_swap: list,
+    ) -> None:
+        m, *_ = orch
+        signed = {"n": 0}
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl"])
+        m._step_swap_service_safe_owner(
+            ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+            service_safe="0xms", qs_master_safe="0xqs",
+            pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: signed.update(n=signed["n"] + 1),
+        )
+        assert fake_swap == []
+        assert signed["n"] == 0
+
+    def test_owners_unreadable_wraps(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_swap: list,
+    ) -> None:
+        m, *_ = orch
+        def boom(**kw: Any) -> Any:
+            raise RuntimeError("rpc 502")
+        monkeypatch.setattr(m, "safe_owners", boom)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_swap_service_safe_owner(
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                service_safe="0xms", qs_master_safe="0xqs",
+                pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        assert "could not read service Safe owners" in ei.value.reason
+
+    def test_qs_not_owner_raises(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_swap: list,
+    ) -> None:
+        m, *_ = orch
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xstranger"])
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_swap_service_safe_owner(
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                service_safe="0xms", qs_master_safe="0xqs",
+                pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        assert "can't swap" in ei.value.reason
+
+    def test_success_path_signs_then_swaps(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch, fake_swap: list,
+    ) -> None:
+        m, *_ = orch
+        signed = {"n": 0}
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        m._step_swap_service_safe_owner(
+            ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+            service_safe="0xms", qs_master_safe="0xqs",
+            pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
+            ensure_signable=lambda: signed.update(n=signed["n"] + 1),
+        )
+        assert signed["n"] == 1 and len(fake_swap) == 1
+
+    def test_swap_failure_wraps_into_half_state_message(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        m, *_ = orch
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        fake_mod = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_mod.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
+        def boom(**kw: Any) -> None:
+            raise RuntimeError("safe tx revert")
+        fake_mod.swap_service_safe_owner = boom  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_mod)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._step_swap_service_safe_owner(
+                ledger_api="LA", qs_wallet=types.SimpleNamespace(crypto="CR"),
+                service_safe="0xms", qs_master_safe="0xqs",
+                pearl_master_safe="0xpl", sid="sc-aaa", chain_str="gnosis",
+                ensure_signable=lambda: None,
+            )
+        # Half-state message must call out the inconsistency.
+        assert "service Safe owner swap failed" in ei.value.reason
+        assert "still lists 0xqs as owner" in ei.value.reason
+
+
+class TestUnmigratableExceptionInit:
+    """Verify _Unmigratable.args is populated so traceback/log formatters preserve fields."""
+
+    def test_args_populated(self, orch: Any) -> None:
+        m, *_ = orch
+        exc = m._Unmigratable(
+            service_id="sc-aaa", chain="gnosis", reason="boom",
+        )
+        # Without __post_init__, the dataclass-synthesized __init__ leaves
+        # args=(). With it, the structured fields propagate to Exception.
+        assert exc.args == ("sc-aaa", "gnosis", "boom")
+
+    def test_repr_shows_all_fields(self, orch: Any) -> None:
+        m, *_ = orch
+        exc = m._Unmigratable(
+            service_id="sc-aaa", chain="gnosis", reason="boom",
+        )
+        # The dataclass-synthesized `__repr__` (which overrides Exception's
+        # default) renders every field by name.
+        r = repr(exc)
+        assert "sc-aaa" in r and "gnosis" in r and "boom" in r
+
+    def test_chain_none_keeps_args_aligned_with_init(self, orch: Any) -> None:
+        """`chain=None` is part of args even if it's None — args MUST stay
+        positionally aligned with `__init__`'s signature so serialization
+        round-trips (`cls(*args)`) reconstruct the same object. The round-4
+        attempt to filter None broke this contract; round 5 restored it
+        + added `__reduce__` so the alignment is explicit."""
+        m, *_ = orch
+        exc = m._Unmigratable(
+            service_id="sc-aaa", chain=None, reason="config malformed",
+        )
+        assert exc.args == ("sc-aaa", None, "config malformed")
+        # str(exc) (custom __str__) elides "on None" so the user-visible
+        # message stays clean.
+        s = str(exc)
+        assert "on None" not in s
+        assert "sc-aaa" in s and "config malformed" in s
+
+    def test_serialization_round_trips(self, orch: Any) -> None:
+        """`__reduce__` must reconstruct the exception identically — verified
+        end-to-end via copy.copy (which uses __reduce__ under the hood).
+        Guards against multiprocessing transport breaking on _Unmigratable."""
+        import copy
+        m, *_ = orch
+        original = m._Unmigratable(
+            service_id="sc-aaa", chain=None, reason="boom",
+        )
+        clone = copy.copy(original)
+        assert clone == original
+        assert clone.service_id == "sc-aaa"
+        assert clone.chain is None
+        assert clone.reason == "boom"
+
+    @pytest.mark.parametrize("chain", [None, "gnosis"])
+    def test_pickle_round_trip(self, chain: Any) -> None:  # noqa: ANN001
+        """Stated motivation for `__reduce__` is multiprocessing transport,
+        which uses pickle (NOT copy). Verify the actual contract directly,
+        for both chain=None and chain set.
+
+        Imports from the canonical module path (not the orch fixture) so
+        pickle's class-by-qualname lookup resolves correctly — the orch
+        fixture intentionally re-imports the module in some configurations
+        and would fail pickle's `cls is sys.modules[mod].cls` identity
+        check, which would mask the real contract being tested."""
+        import pickle  # noqa: S403 — internal serialization, not untrusted input
+        from scripts.pearl_migration.migrate_to_pearl import _Unmigratable
+        original = _Unmigratable(
+            service_id="sc-aaa", chain=chain, reason="boom",
+        )
+        clone = pickle.loads(pickle.dumps(original))  # noqa: S301
+        assert isinstance(clone, _Unmigratable)
+        assert clone == original
+        assert clone.service_id == "sc-aaa"
+        assert clone.chain == chain
+        assert clone.reason == "boom"
+
+
+class TestMigrateOneService:
+    @pytest.fixture(autouse=True)
+    def _stub_threshold(self, orch: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default the threshold pre-flight to 1 so individual tests don't all
+        have to mock it. Tests that exercise the threshold check override."""
+        m, *_ = orch
+        monkeypatch.setattr(m, "safe_threshold", lambda **kw: 1)
+        # `_migrate_one_service` re-probes containers after force-cleanup
+        # to detect the docker-daemon-hang case. Default to "no leftovers"
+        # so tests don't all have to stub this themselves.
+        monkeypatch.setattr(m, "docker_quickstart_containers", lambda: [])
+
+    def _make_service_obj(
+        self, fake_chain_cls: Any, *, multisig: str = "0xms", token: int = 7,
+    ) -> Any:
+        chain_data = types.SimpleNamespace(token=token, multisig=multisig)
+        ledger_config = types.SimpleNamespace(rpc="http://rpc")
+        chain_config = types.SimpleNamespace(
+            chain_data=chain_data, ledger_config=ledger_config,
+        )
+        return types.SimpleNamespace(chain_configs={"gnosis": chain_config})
+
+    def _setup_manager(
+        self, FakeChain: Any, FakeOnChainState: Any,
+        *,
+        terminate: Any = None,
+        state_seq: Optional[list] = None,
+        multisig: str = "0xms",
+    ) -> tuple[Any, Any]:
+        """Build a manager mock. `state_seq` lets the probe return a different
+        state on the second call (after-terminate check)."""
+        if terminate is None:
+            terminate = lambda **kw: None  # noqa: E731 -- default no-op
+        states = list(state_seq or [
+            FakeOnChainState.DEPLOYED,         # before terminate
+            FakeOnChainState.PRE_REGISTRATION, # after terminate
+        ])
+        svc_obj = self._make_service_obj(FakeChain, multisig=multisig)
+        return svc_obj, types.SimpleNamespace(
+            load=lambda service_config_id: svc_obj,
+            terminate_service_on_chain_from_safe=terminate,
+            _get_on_chain_state=lambda s, c: states.pop(0) if states else FakeOnChainState.PRE_REGISTRATION,
+            get_eth_safe_tx_builder=lambda ledger_config: types.SimpleNamespace(
+                ledger_api="LA",
+            ),
+        )
+
+    def test_success(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        manager_calls: dict[str, Any] = {}
+
+        def fake_terminate(service_config_id: str, chain: str) -> None:
+            manager_calls["term"] = chain
+
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState, terminate=fake_terminate,
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        qs_wallet = types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"})
+        pearl_wallet = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"})
+
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # Idempotency probes: NFT not yet transferred, qs Safe still owns service Safe.
+        monkeypatch.setattr(m, "service_nft_owner",
+                            lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+
+        # Stub the lazy transfer-module import.
+        fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        moves: list[Any] = []
+        def fake_nft(**kw: Any) -> str:
+            moves.append(("nft", kw)); return "0x1"
+        def fake_swap(**kw: Any) -> None:
+            moves.append(("swap", kw))
+        fake_transfer.transfer_service_nft = fake_nft  # type: ignore[attr-defined]
+        fake_transfer.swap_service_safe_owner = fake_swap  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "scripts.pearl_migration.transfer", fake_transfer,
+        )
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=["0xa"], path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app, qs_wallet=qs_wallet,
+            pearl_wallet=pearl_wallet, config_path="cfg.json",
+        )
+        assert manager_calls["term"] == "gnosis"
+        assert [step for step, _ in moves] == ["nft", "swap"]
+
+    def test_idempotent_skips_when_already_done(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-run after partial completion: NFT already on Pearl, Safe owner already swapped."""
+        m, FakeChain, FakeOnChainState = orch
+        terminate_calls: list[Any] = []
+
+        def fake_terminate(**kw: Any) -> None:
+            terminate_calls.append(kw)
+
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            terminate=fake_terminate,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],  # already there
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        qs_wallet = types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"})
+        pearl_wallet = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"})
+
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # NFT already on Pearl, Safe owner already swapped to Pearl.
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl"])
+
+        fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        nft_called: list[Any] = []
+        swap_called: list[Any] = []
+        fake_transfer.transfer_service_nft = lambda **kw: nft_called.append(kw)  # type: ignore[attr-defined]
+        fake_transfer.swap_service_safe_owner = lambda **kw: swap_called.append(kw)  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "scripts.pearl_migration.transfer", fake_transfer,
+        )
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app, qs_wallet=qs_wallet,
+            pearl_wallet=pearl_wallet, config_path=None,
+        )
+        # Every on-chain step was probed-and-skipped.
+        assert terminate_calls == [], "terminate must be skipped when already PRE_REGISTRATION"
+        assert nft_called == [], "transfer_service_nft must be skipped when NFT already on Pearl"
+        assert swap_called == [], "swap_service_safe_owner must be skipped when already swapped"
+
+    def test_nft_owner_unreadable_raises_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: None)  # RPC failure
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert ei.value.chain == "gnosis"
+        assert "could not read NFT owner" in ei.value.reason
+
+    def test_nft_owner_unexpected_third_party_raises(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # NFT now lives on some unrelated address.
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xstranger")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "NFT owner is" in ei.value.reason
+
+    def test_nft_transfer_failure_raises_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+
+        fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        def boom(**kw: Any) -> None:
+            raise RuntimeError("revert: nonce stale")
+        fake_transfer.transfer_service_nft = boom  # type: ignore[attr-defined]
+        fake_transfer.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "scripts.pearl_migration.transfer", fake_transfer,
+        )
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "NFT transfer failed" in ei.value.reason
+
+    def test_swap_failure_raises_unmigratable_post_nft(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Critical: swap fails AFTER NFT transferred -> structured error explains the half-state."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+
+        # Track ordering: NFT transfer MUST land before swap raises so the
+        # half-state message is true. A future refactor that reorders the
+        # steps would make the error message a lie — pin the contract here.
+        order: list[str] = []
+        fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        def fake_nft(**kw: Any) -> str:
+            order.append("nft"); return "0x1"
+        def swap_boom(**kw: Any) -> None:
+            order.append("swap"); raise RuntimeError("safe tx revert")
+        fake_transfer.transfer_service_nft = fake_nft  # type: ignore[attr-defined]
+        fake_transfer.swap_service_safe_owner = swap_boom  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "scripts.pearl_migration.transfer", fake_transfer,
+        )
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        # Half-state must be called out so the user knows what's been moved.
+        assert "service multisig" in ei.value.reason
+        assert "owner swap failed" in ei.value.reason
+        # And the half-state message must actually be true: NFT transferred FIRST.
+        assert order == ["nft", "swap"], (
+            f"swap must run AFTER nft transfer for the half-state message to be true; saw {order}"
+        )
+
+    def test_terminate_failure_raises_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        def boom(service_config_id: str, chain: str) -> None:
+            raise RuntimeError("can't unstake yet")
+        # State is DEPLOYED before terminate runs (so the probe says "act").
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            terminate=boom, state_seq=[FakeOnChainState.DEPLOYED],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: (_ for _ in ()).throw(RuntimeError("stop fails too")))
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path="cfg.json",
+            )
+        assert ei.value.chain == "gnosis"
+        assert "could not unstake" in ei.value.reason
+
+    def test_wrong_state_after_terminate_raises(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        # Both probes return DEPLOYED — terminate "succeeds" but state never moves.
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.DEPLOYED, FakeOnChainState.DEPLOYED],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path="cfg.json",
+            )
+        assert "expected PRE_REGISTRATION" in ei.value.reason
+
+    def test_safe_owners_unreadable_raises_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # NFT was already transferred (so we get past step 2), but reading
+        # owners fails (RPC down).
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
+        def owners_boom(**kw: Any) -> Any:
+            raise RuntimeError("rpc down")
+        monkeypatch.setattr(m, "safe_owners", owners_boom)
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "could not read service Safe owners" in ei.value.reason
+
+    def test_safe_owner_swap_required_but_qs_not_owner(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Swap can't proceed if the qs Safe was already removed by some third party."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # NFT already on Pearl (so step 2 is skipped without needing real transfer).
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
+        # Service Safe owners: neither qs nor pearl present.
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xstranger"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "can't swap" in ei.value.reason
+
+    def test_multi_chain_per_iteration_ledger_capture(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Service spans 2 chains: each iteration's `_ledger_api(_cfg=...)`
+        default-arg binding must capture THAT iteration's chain_config.
+
+        If the binding regresses to a global `nonlocal` only, both iterations
+        would build the ledger from chain N+1's config (Python's late-binding
+        in for-loop closures). This test pins the per-chain capture by
+        recording which RPC each step's ledger came from.
+        """
+        m, FakeChain, FakeOnChainState = orch
+        # Two distinct chain_configs, distinguished by RPC.
+        cc_g = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(token=1, multisig="0xms-g"),
+            ledger_config=types.SimpleNamespace(rpc="https://rpc.example/gnosis"),
+        )
+        cc_o = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(token=2, multisig="0xms-o"),
+            ledger_config=types.SimpleNamespace(rpc="https://rpc.example/optimism"),
+        )
+        svc_obj = types.SimpleNamespace(
+            chain_configs={"gnosis": cc_g, "optimism": cc_o},
+        )
+
+        # Record which ledger_config each manager.get_eth_safe_tx_builder
+        # call was invoked with — that's the proxy for "did the closure
+        # capture the per-iteration config?"
+        builds: list = []
+        manager = types.SimpleNamespace(
+            load=lambda service_config_id: svc_obj,
+            terminate_service_on_chain_from_safe=lambda **kw: None,
+            _get_on_chain_state=lambda s, c: FakeOnChainState.PRE_REGISTRATION,
+            get_eth_safe_tx_builder=(
+                lambda ledger_config: (
+                    builds.append(ledger_config.rpc)
+                    or types.SimpleNamespace(ledger_api=f"LA-{ledger_config.rpc}")
+                )
+            ),
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+
+        # NFT already on the per-chain Pearl Safe, Safe already swapped:
+        # step 2 + step 3 skip, but step 1 (terminate) still runs and
+        # invokes ensure_signable → safe_threshold → _ledger_api per chain.
+        # `service_id` lets us return the right per-chain Pearl address
+        # (token=1 → gnosis, token=2 → optimism).
+        per_chain_pearl = {1: "0xpl-g", 2: "0xpl-o"}
+        monkeypatch.setattr(
+            m, "service_nft_owner",
+            lambda *, ledger_api, service_registry_address, service_id:
+                per_chain_pearl[service_id],
+        )
+        monkeypatch.setattr(
+            m, "safe_owners",
+            lambda *, ledger_api, safe:
+                ["0xpl-g"] if safe == "0xms-g" else ["0xpl-o"],
+        )
+        # Override the autouse stub so safe_threshold actually runs against
+        # the per-chain ledger_api.
+        seen_thresholds: list = []
+        def threshold_recorder(*, ledger_api: Any, safe: str) -> int:
+            seen_thresholds.append(ledger_api)
+            return 1
+        monkeypatch.setattr(m, "safe_threshold", threshold_recorder)
+        # Force a state mismatch so terminate runs — that triggers the
+        # threshold guard (which calls _ledger_api → records the build).
+        states = iter([
+            FakeOnChainState.DEPLOYED, FakeOnChainState.PRE_REGISTRATION,  # gnosis
+            FakeOnChainState.DEPLOYED, FakeOnChainState.PRE_REGISTRATION,  # optimism
+        ])
+        manager._get_on_chain_state = lambda s, c: next(states)  # type: ignore[attr-defined]
+
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+
+        ref = _fake_service("sc-aaa", name="A", path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app,
+            qs_wallet=types.SimpleNamespace(crypto="CR", safes={
+                FakeChain.GNOSIS: "0xqs-g", FakeChain.OPTIMISM: "0xqs-o",
+            }),
+            pearl_wallet=types.SimpleNamespace(safes={
+                FakeChain.GNOSIS: "0xpl-g", FakeChain.OPTIMISM: "0xpl-o",
+            }),
+            config_path=None,
+        )
+
+        # Each chain's ledger_api was built from its OWN rpc. The bug we're
+        # guarding against would build both ledgers from the optimism rpc
+        # (last iteration's chain_config bound by all closures).
+        assert "https://rpc.example/gnosis" in builds
+        assert "https://rpc.example/optimism" in builds
+        # And the two threshold calls received distinct ledger handles
+        # (one per chain).
+        assert "LA-https://rpc.example/gnosis" in seen_thresholds
+        assert "LA-https://rpc.example/optimism" in seen_thresholds
+
+    def test_multi_chain_steps_2_and_3_use_per_iteration_ledger(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Sibling to the previous test: this time NFT is still on the QS
+        Safe and the service Safe is still QS-owned, so step 2 (NFT transfer)
+        AND step 3 (Safe owner swap) BOTH run on BOTH chains. Asserts that
+        the ledger_api passed into `transfer_service_nft` and
+        `swap_service_safe_owner` was the per-chain one — closes the
+        coverage gap where the prior test only exercised the threshold
+        guard, leaving the late-binding risk on steps 2/3 unverified."""
+        m, FakeChain, FakeOnChainState = orch
+        cc_g = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(token=1, multisig="0xms-g"),
+            ledger_config=types.SimpleNamespace(rpc="https://rpc.example/gnosis"),
+        )
+        cc_o = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(token=2, multisig="0xms-o"),
+            ledger_config=types.SimpleNamespace(rpc="https://rpc.example/optimism"),
+        )
+        svc_obj = types.SimpleNamespace(
+            chain_configs={"gnosis": cc_g, "optimism": cc_o},
+        )
+
+        # Each call to get_eth_safe_tx_builder gets a fresh ledger handle
+        # tagged with the chain's RPC, so we can fingerprint which one
+        # downstream calls received.
+        manager = types.SimpleNamespace(
+            load=lambda service_config_id: svc_obj,
+            terminate_service_on_chain_from_safe=lambda **kw: None,
+            _get_on_chain_state=lambda s, c: FakeOnChainState.PRE_REGISTRATION,
+            get_eth_safe_tx_builder=(
+                lambda ledger_config:
+                    types.SimpleNamespace(ledger_api=f"LA-{ledger_config.rpc}")
+            ),
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+
+        # NFT still owned by per-chain QS Safe -> step 2 must run.
+        per_chain_qs = {1: "0xqs-g", 2: "0xqs-o"}
+        monkeypatch.setattr(
+            m, "service_nft_owner",
+            lambda *, ledger_api, service_registry_address, service_id:
+                per_chain_qs[service_id],
+        )
+        # Service Safe still QS-owned -> step 3 must run.
+        monkeypatch.setattr(
+            m, "safe_owners",
+            lambda *, ledger_api, safe:
+                ["0xqs-g"] if safe == "0xms-g" else ["0xqs-o"],
+        )
+        monkeypatch.setattr(m, "safe_threshold", lambda *, ledger_api, safe: 1)
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+
+        nft_calls: list = []
+        swap_calls: list = []
+        from scripts.pearl_migration import transfer as transfer_mod
+        monkeypatch.setattr(
+            transfer_mod, "transfer_service_nft",
+            lambda *, ledger_api, crypto, service_registry_address,
+                   qs_master_safe, pearl_master_safe, service_id:
+                nft_calls.append((ledger_api, service_id)),
+        )
+        monkeypatch.setattr(
+            transfer_mod, "swap_service_safe_owner",
+            lambda *, ledger_api, crypto, service_safe, old_owner, new_owner:
+                swap_calls.append((ledger_api, service_safe)),
+        )
+
+        ref = _fake_service("sc-aaa", name="A", path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app,
+            qs_wallet=types.SimpleNamespace(crypto="CR", safes={
+                FakeChain.GNOSIS: "0xqs-g", FakeChain.OPTIMISM: "0xqs-o",
+            }),
+            pearl_wallet=types.SimpleNamespace(safes={
+                FakeChain.GNOSIS: "0xpl-g", FakeChain.OPTIMISM: "0xpl-o",
+            }),
+            config_path=None,
+        )
+
+        # Step 2: each chain's NFT transfer received its own ledger handle.
+        assert ("LA-https://rpc.example/gnosis", 1) in nft_calls
+        assert ("LA-https://rpc.example/optimism", 2) in nft_calls
+        # Step 3: each chain's swap received its own ledger handle, keyed by
+        # the per-chain service Safe (multisig) address.
+        assert ("LA-https://rpc.example/gnosis", "0xms-g") in swap_calls
+        assert ("LA-https://rpc.example/optimism", "0xms-o") in swap_calls
+
+    def test_creates_pearl_safe_when_missing(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pearl missing a Safe on this chain -> create_safe is invoked, then proceed."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],  # already there, skip terminate
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # NFT already on (the soon-to-be-created) Pearl, swap already done.
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl-new")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl-new"])
+
+        # Pearl wallet starts with NO Safe on Gnosis. `create_safe` should be
+        # called and populate `safes[chain]`.
+        pearl_safes: dict = {}
+        creates: list = []
+
+        def fake_create_safe(*, chain: Any, rpc: Any) -> None:
+            creates.append({"chain": chain, "rpc": rpc})
+            pearl_safes[chain] = "0xpl-new"
+        pearl_wallet = types.SimpleNamespace(safes=pearl_safes, create_safe=fake_create_safe)
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app,
+            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            pearl_wallet=pearl_wallet, config_path=None,
+        )
+        assert len(creates) == 1
+        assert creates[0]["chain"] == FakeChain.GNOSIS
+        assert pearl_safes[FakeChain.GNOSIS] == "0xpl-new"
+
+    def test_pearl_safe_creation_failure_is_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+
+        def boom(**kw: Any) -> None:
+            raise RuntimeError("rpc rejected safe deployment")
+        pearl_wallet = types.SimpleNamespace(safes={}, create_safe=boom)
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=pearl_wallet, config_path=None,
+            )
+        assert "could not create Pearl master Safe" in ei.value.reason
+
+    def test_force_remove_timeout_becomes_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`force_remove_known_containers` raising `TimeoutExpired` (docker
+        daemon hang) MUST surface as `_Unmigratable` — not propagate raw
+        and abort the batch with on-chain ops about to commit."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        def boom() -> list:
+            raise subprocess.TimeoutExpired(cmd=["docker", "rm"], timeout=30)
+        monkeypatch.setattr(m, "force_remove_known_containers", boom)
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "could not confirm containers are stopped" in ei.value.reason
+
+    @pytest.mark.parametrize("bug_cls", [
+        TypeError, AttributeError, NameError, ImportError,
+    ])
+    def test_stop_via_middleware_programming_bug_propagates(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        bug_cls: type,
+    ) -> None:
+        """A programming bug in middleware's stop_service must NOT be
+        demoted to a `warn(...)` and silently fall through to the
+        on-chain branch — propagate as a real traceback."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        def buggy(operate: Any, config_path: str) -> None:
+            raise bug_cls("middleware refactor")
+        monkeypatch.setattr(m, "stop_via_middleware", buggy)
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(bug_cls):
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path="cfg.json",
+            )
+
+    @pytest.mark.parametrize("bug_cls", [
+        TypeError, AttributeError, NameError, ImportError,
+    ])
+    def test_pearl_create_safe_programming_bug_propagates(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        bug_cls: type,
+    ) -> None:
+        """Programming bug in `pearl_wallet.create_safe` must propagate,
+        not get wrapped as `_Unmigratable("could not create Pearl Safe")`."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        def buggy(**kw: Any) -> None:
+            raise bug_cls("middleware refactor")
+        pearl_wallet = types.SimpleNamespace(safes={}, create_safe=buggy)
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(bug_cls):
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=pearl_wallet, config_path=None,
+            )
+
+    @pytest.mark.parametrize("bug_cls", [
+        TypeError, AttributeError, NameError, ImportError,
+    ])
+    def test_ensure_signable_programming_bug_propagates(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        bug_cls: type,
+    ) -> None:
+        """A programming bug in `safe_threshold` (caller of
+        `_ensure_signable`) must propagate, not become an
+        `_Unmigratable("could not read threshold")`."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        def buggy(**kw: Any) -> None:
+            raise bug_cls("middleware refactor")
+        monkeypatch.setattr(m, "safe_threshold", buggy)
+        # Force the signing branch by ensuring NFT is still on QS.
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(bug_cls):
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+
+    def test_force_remove_runtime_error_becomes_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`docker_quickstart_containers` raising `RuntimeError` (docker
+        daemon refusing to talk) MUST surface as `_Unmigratable`."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        def boom() -> list:
+            raise RuntimeError("docker ps exited 1: permission denied")
+        monkeypatch.setattr(m, "force_remove_known_containers", boom)
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "could not confirm containers are stopped" in ei.value.reason
+
+    def test_re_probe_runtime_error_becomes_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Re-probe via `docker_quickstart_containers` failing AFTER a
+        clean `force_remove_known_containers` MUST also become
+        `_Unmigratable`. Covers the daemon-hangs-between-rm-and-ps race."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        def boom() -> list:
+            raise RuntimeError("docker ps exited 1: daemon gone")
+        monkeypatch.setattr(m, "docker_quickstart_containers", boom)
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "could not verify containers stopped" in ei.value.reason
+
+    def test_leftover_containers_after_cleanup_become_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If `docker rm -f` reported success but containers are still
+        listed afterwards (daemon refused without erroring), MUST surface
+        as `_Unmigratable` — proceeding would race the live deployment."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: ["abci0"])
+        # Override the autouse stub: re-probe still finds the container.
+        monkeypatch.setattr(m, "docker_quickstart_containers", lambda: ["abci0"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "still running after cleanup" in ei.value.reason
+        assert "abci0" in ei.value.reason
+
+    def test_qs_wallet_missing_chain_safe_is_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`qs_wallet.safes[chain]` raising KeyError (chain added to service
+        after wallet creation) must surface as a per-service `_Unmigratable`,
+        NOT crash the batch — `_PROGRAMMING_BUGS` deliberately excludes
+        KeyError so this wrap at the call site is the only thing keeping
+        the contract."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                # No Safe registered for Gnosis -> KeyError on access.
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "no Safe on gnosis" in ei.value.reason
+
+    def test_contracts_missing_chain_is_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CONTRACTS[chain]['service_registry'] raising KeyError (newer chain
+        enum without a registered ServiceRegistry) must surface as a per-
+        service `_Unmigratable`, not crash the batch."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # Strip the registry entry for Gnosis to simulate a chain without
+        # a registered ServiceRegistry.
+        from operate.ledger.profiles import CONTRACTS as _CONTRACTS
+        original = _CONTRACTS.get(FakeChain.GNOSIS, {}).copy()
+        _CONTRACTS[FakeChain.GNOSIS] = {
+            k: v for k, v in original.items() if k != "service_registry"
+        }
+        try:
+            ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+            with pytest.raises(m._Unmigratable) as ei:
+                m._migrate_one_service(
+                    svc=ref, qs_app=qs_app,
+                    qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                    pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                    config_path=None,
+                )
+            assert "no ServiceRegistry contract" in ei.value.reason
+        finally:
+            _CONTRACTS[FakeChain.GNOSIS] = original
+
+    def test_threshold_gt_1_raises_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multi-sig master Safe with threshold > 1 must be refused upfront."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "safe_threshold", lambda **kw: 2)   # multi-sig
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "threshold" in ei.value.reason and "single-owner only" in ei.value.reason
+
+    def test_threshold_zero_distinct_message(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Threshold == 0 (malformed Safe) must NOT say 'lower the threshold'."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "safe_threshold", lambda **kw: 0)
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "appears unconfigured" in ei.value.reason
+        assert "Lower the threshold" not in ei.value.reason
+
+    def test_threshold_check_skipped_when_already_migrated(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Resumed run on a fully-migrated service must NOT call safe_threshold.
+
+        This catches the regression where the threshold pre-check was placed
+        before the per-step probes — a user who raised their qs Safe threshold
+        after migrating would have been refused on a no-op resume.
+        """
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(
+            FakeChain, FakeOnChainState,
+            state_seq=[FakeOnChainState.PRE_REGISTRATION],   # already terminated
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # NFT already on Pearl, Safe already swapped → no signing needed.
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl"])
+
+        threshold_calls: list = []
+        def boom_threshold(**kw: Any) -> int:
+            threshold_calls.append(kw)
+            # Simulate user having raised threshold post-migration; would
+            # raise _Unmigratable IF the check ran.
+            return 2
+        monkeypatch.setattr(m, "safe_threshold", boom_threshold)
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        # Should complete cleanly: no signing → no threshold check.
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app,
+            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+            config_path=None,
+        )
+        assert threshold_calls == [], (
+            "safe_threshold must NOT be called when no signing branch runs"
+        )
+
+    def test_threshold_actually_invoked_when_signing(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Sanity that the threshold pre-check DOES run when we actually sign.
+
+        The autouse `_stub_threshold` masks the call site in most tests; this
+        one bypasses the stub by overriding it to record invocations.
+        """
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+
+        invocations: list = []
+        def recording_threshold(**kw: Any) -> int:
+            invocations.append(kw)
+            return 1
+        monkeypatch.setattr(m, "safe_threshold", recording_threshold)
+
+        fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
+        fake_transfer.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "scripts.pearl_migration.transfer", fake_transfer)
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app,
+            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+            config_path=None,
+        )
+        assert invocations, "safe_threshold should be invoked before signing"
+        # Each call must pass the QS master Safe address (not Pearl's).
+        for call in invocations:
+            assert call.get("safe") == "0xqs"
+
+    def test_threshold_read_failure_raises_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware", lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+
+        def boom(**kw: Any) -> Any:
+            raise RuntimeError("rpc 502")
+        monkeypatch.setattr(m, "safe_threshold", boom)
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+                pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+                config_path=None,
+            )
+        assert "could not read quickstart master Safe threshold" in ei.value.reason
+
+    def test_print_summary_clean_prints_success(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """All-clean migration: prints a positive 'fully migrated: N' headline."""
+        m, *_ = orch
+        outcome = m.MigrationOutcome(
+            migrated=tuple(_fake_service(f"sc-{i}") for i in range(4)),
+        )
+        m._print_migration_summary(outcome)
+        out = capsys.readouterr().out
+        assert "Migration summary" in out
+        assert "fully migrated: 4 service(s)" in out
+        assert "Migration incomplete" not in out
+
+    def test_print_summary_formats_each_failure_line(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Direct check on the per-failure formatting — would catch a typo
+        in the `[chain] kind address: reason` template."""
+        m, FakeChain, _ = orch
+        unm = (m._Unmigratable(
+            service_id="sc-zzz", chain="gnosis", reason="cannot unstake yet",
+        ),)
+        drains = (
+            m._DrainFailure(
+                chain=FakeChain.GNOSIS, source_kind="Safe",
+                source_address="0xsafe-addr", reason="insufficient gas",
+            ),
+            m._DrainFailure(
+                chain=FakeChain.OPTIMISM, source_kind="EOA",
+                source_address="0xeoa-addr", reason="rpc 502",
+            ),
+        )
+        outcome = m.MigrationOutcome(
+            migrated=tuple(_fake_service(f"sc-{i}") for i in range(2)),
+            unmigratable=unm,
+            drain_failures=drains,
+        )
+        m._print_migration_summary(outcome)
+        out = capsys.readouterr().out
+        assert "Migration incomplete" in out
+        assert "fully migrated: 2 service(s)" in out
+        assert "un-migrated services: 1" in out
+        assert "sc-zzz" in out and "cannot unstake yet" in out
+        assert "drain failures: 2" in out
+        # Per-line format checks (chain.name comes from FakeChain.name attribute).
+        assert "[GNOSIS] Safe 0xsafe-addr: insufficient gas" in out
+        assert "[OPTIMISM] EOA 0xeoa-addr: rpc 502" in out
+
+    def test_no_config_path_skips_middleware_stop(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        called: list[str] = []
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda **kw: called.append("nope"))
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xqs")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xqs"])
+        fake_transfer = types.ModuleType("scripts.pearl_migration.transfer")
+        fake_transfer.transfer_service_nft = lambda **kw: "0x1"  # type: ignore[attr-defined]
+        fake_transfer.swap_service_safe_owner = lambda **kw: None  # type: ignore[attr-defined]
+        monkeypatch.setitem(
+            sys.modules, "scripts.pearl_migration.transfer", fake_transfer,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app,
+            qs_wallet=types.SimpleNamespace(crypto="CR", safes={FakeChain.GNOSIS: "0xqs"}),
+            pearl_wallet=types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"}),
+            config_path=None,
+        )
+        assert called == []  # config_path None bypasses stop_via_middleware
+
+
+class TestDrainMaster:
+    def test_announces_pearl_safe_creation(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When Pearl lacks a Safe on a chain we announce + create rather than skip."""
+        m, FakeChain, _ = orch
+        pearl_safes: dict = {}
+
+        def fake_create_safe(*, chain: Any, rpc: Any) -> None:
+            pearl_safes[chain] = "0xpl"
+
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=lambda **kw: {})
+        pearl = types.SimpleNamespace(safes=pearl_safes,
+                                      create_safe=fake_create_safe,
+                                      address="0xpe")
+        m._drain_master(
+            qs_wallet=qs, pearl_wallet=pearl,
+            chain_rpcs={FakeChain.GNOSIS: "https://rpc/gnosis"},
+        )
+        out = capsys.readouterr().out
+        assert "Pearl has no master Safe" in out and "creating one" in out
+
+    def test_drain_empty_moved_emits_info_line(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When `qs_wallet.drain()` returns `{}`, emit an explicit "no
+        balances to move" line so silence isn't ambiguous between
+        "nothing to drain" and "silently dropped"."""
+        m, FakeChain, _ = orch
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=lambda **kw: {})
+        pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
+                                      address="0xpe")
+        m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
+        out = capsys.readouterr().out
+        assert "no balances to move from Safe on GNOSIS" in out
+        assert "no balances to move from EOA on GNOSIS" in out
+
+    def test_drain_safe_and_eoa(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, FakeChain, _ = orch
+        called: list[dict[str, Any]] = []
+        def fake_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict[str, int]:
+            called.append({"to": withdrawal_address, "from_safe": from_safe})
+            return {"0xtoken": 100}
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=fake_drain)
+        pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
+                                      address="0xpe")
+        failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
+        assert failures == []
+        assert {c["from_safe"] for c in called} == {True, False}
+        assert called[0]["to"] == "0xpl"
+        assert called[1]["to"] == "0xpe"
+
+    def test_drain_safe_failure_returns_failure_record(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        m, FakeChain, _ = orch
+        def fake_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict[str, int]:
+            if from_safe:
+                raise RuntimeError("safe drain boom")
+            return {}
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=fake_drain)
+        pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
+                                      address="0xpe")
+        failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
+        assert len(failures) == 1
+        assert failures[0].source_kind == "Safe"
+        assert "boom" in failures[0].reason
+        assert "drain (Safe)" in capsys.readouterr().out
+
+    def test_drain_eoa_failure_returns_failure_record(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        m, FakeChain, _ = orch
+        def fake_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict[str, int]:
+            if not from_safe:
+                raise RuntimeError("eoa drain boom")
+            return {}
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=fake_drain)
+        pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
+                                      address="0xpe")
+        failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
+        assert len(failures) == 1
+        assert failures[0].source_kind == "EOA"
+        assert "drain (EOA)" in capsys.readouterr().out
+
+    def test_drain_creates_pearl_safe_when_missing(
+        self, orch: Any,
+    ) -> None:
+        """If Pearl has no Safe on a chain, create one then drain into it."""
+        m, FakeChain, _ = orch
+        # Track create_safe calls and have them populate Pearl's safes dict.
+        pearl_safes: dict = {}
+        creates: list = []
+
+        def fake_create_safe(*, chain: Any, rpc: Any) -> None:
+            creates.append({"chain": chain, "rpc": rpc})
+            pearl_safes[chain] = "0xpl-fresh"
+
+        called: list = []
+        def fake_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict:
+            called.append({"to": withdrawal_address, "from_safe": from_safe})
+            return {}
+
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=fake_drain)
+        pearl = types.SimpleNamespace(safes=pearl_safes,
+                                      create_safe=fake_create_safe,
+                                      address="0xpe")
+        failures = m._drain_master(
+            qs_wallet=qs, pearl_wallet=pearl,
+            chain_rpcs={FakeChain.GNOSIS: "https://rpc.example/gnosis"},
+        )
+        assert failures == []
+        assert creates == [{"chain": FakeChain.GNOSIS,
+                            "rpc": "https://rpc.example/gnosis"}]
+        # Drains then ran into the freshly-created Pearl Safe.
+        assert called[0]["to"] == "0xpl-fresh"
+        assert called[1]["to"] == "0xpe"
+
+    @pytest.mark.parametrize("bug_cls", [
+        TypeError, AttributeError, NameError, ImportError,
+    ])
+    def test_drain_programming_bug_propagates(
+        self, orch: Any, bug_cls: type,
+    ) -> None:
+        """A programming bug in `qs_wallet.drain()` (e.g. middleware
+        signature drift) MUST propagate as a real traceback, NOT get
+        silently aggregated into `_DrainFailure` where the user would
+        chase 'RPC retry' instead of the real bug."""
+        m, FakeChain, _ = orch
+        def buggy_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict:
+            raise bug_cls("simulated middleware refactor bug")
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=buggy_drain)
+        pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
+                                      address="0xpe")
+        with pytest.raises(bug_cls):
+            m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
+
+    @pytest.mark.parametrize("bug_cls", [
+        TypeError, AttributeError, NameError, ImportError,
+    ])
+    def test_drain_create_safe_programming_bug_propagates(
+        self, orch: Any, bug_cls: type,
+    ) -> None:
+        """Same policy for the Pearl Safe creation site in `_drain_master`."""
+        m, FakeChain, _ = orch
+        def buggy_create(*, chain: Any, rpc: Any) -> None:
+            raise bug_cls("simulated middleware refactor bug")
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=lambda **kw: {})
+        pearl = types.SimpleNamespace(safes={}, create_safe=buggy_create,
+                                      address="0xpe")
+        with pytest.raises(bug_cls):
+            m._drain_master(
+                qs_wallet=qs, pearl_wallet=pearl,
+                chain_rpcs={FakeChain.GNOSIS: "https://rpc/gnosis"},
+            )
+
+    def test_drain_pearl_safe_creation_failure_records_failure(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        m, FakeChain, _ = orch
+
+        def boom(*, chain: Any, rpc: Any) -> None:
+            raise RuntimeError("create reverted")
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=lambda **kw: {})
+        pearl = types.SimpleNamespace(safes={}, create_safe=boom, address="0xpe")
+        # Provide an RPC so the create_safe boom is reached (new pre-check
+        # would short-circuit otherwise).
+        failures = m._drain_master(
+            qs_wallet=qs, pearl_wallet=pearl,
+            chain_rpcs={FakeChain.GNOSIS: "https://rpc/gnosis"},
+        )
+        assert len(failures) == 1
+        assert failures[0].source_kind == "Safe+EOA"
+        assert "Pearl Safe creation failed" in failures[0].reason
+        assert "could not create Pearl Safe" in capsys.readouterr().out
+
+    def test_drain_skips_chain_with_no_rpc_records_failure(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Pre-check: if Pearl needs a Safe on a chain but `chain_rpcs` has
+        no entry, we MUST NOT pass `rpc=None` to `create_safe` (silent
+        fallback to public RPC). Instead append a `_DrainFailure` and
+        skip the chain so the user sees why funds weren't moved."""
+        m, FakeChain, _ = orch
+        creates: list = []
+
+        def fake_create_safe(*, chain: Any, rpc: Any) -> None:
+            creates.append(chain)
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=lambda **kw: {})
+        pearl = types.SimpleNamespace(safes={}, create_safe=fake_create_safe,
+                                      address="0xpe")
+        failures = m._drain_master(qs_wallet=qs, pearl_wallet=pearl, chain_rpcs={})
+        # create_safe MUST NOT have been called with rpc=None.
+        assert creates == []
+        assert len(failures) == 1
+        assert failures[0].source_kind == "Safe+EOA"
+        assert "no RPC available" in failures[0].reason
+        assert "no RPC available" in capsys.readouterr().out
+
+    def test_drain_per_chain_isolation(
+        self, orch: Any,
+    ) -> None:
+        """Docstring claims one chain's RPC outage shouldn't prevent
+        draining the others. Pin it: chain A's Safe creation fails,
+        chain B's drain MUST still run on both rails."""
+        m, FakeChain, _ = orch
+        drained: list = []
+
+        def fake_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict:
+            drained.append((chain, from_safe))
+            return {}
+
+        def fake_create_safe(*, chain: Any, rpc: Any) -> None:
+            if chain == FakeChain.GNOSIS:
+                raise RuntimeError("rpc down")
+
+        qs = types.SimpleNamespace(
+            safes={FakeChain.GNOSIS: "0xqs-g", FakeChain.OPTIMISM: "0xqs-o"},
+            address="0xqs_eoa", drain=fake_drain,
+        )
+        pearl = types.SimpleNamespace(
+            safes={FakeChain.OPTIMISM: "0xpl-o"},   # missing GNOSIS
+            create_safe=fake_create_safe, address="0xpe",
+        )
+        failures = m._drain_master(
+            qs_wallet=qs, pearl_wallet=pearl,
+            chain_rpcs={FakeChain.GNOSIS: "https://rpc/gnosis"},
+        )
+        # Gnosis aborted (Safe creation failed) -> single failure.
+        assert {(f.chain, f.source_kind) for f in failures} == {
+            (FakeChain.GNOSIS, "Safe+EOA"),
+        }
+        # Optimism still drained both rails — Gnosis short-circuited at
+        # `continue` and did NOT skip Optimism.
+        assert (FakeChain.OPTIMISM, True) in drained
+        assert (FakeChain.OPTIMISM, False) in drained
+        assert (FakeChain.GNOSIS, True) not in drained
+
+    def test_safe_failure_does_not_skip_eoa_on_same_chain(
+        self, orch: Any,
+    ) -> None:
+        """Safe drain failure on chain X must still attempt EOA drain on
+        chain X. A future refactor combining both into one try block
+        would silently strand EOA funds."""
+        m, FakeChain, _ = orch
+        calls: list = []
+
+        def fake_drain(withdrawal_address: str, chain: Any, from_safe: bool) -> dict:
+            calls.append(from_safe)
+            if from_safe:
+                raise RuntimeError("safe drain boom")
+            return {}
+        qs = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xqs"},
+                                   address="0xqs_eoa", drain=fake_drain)
+        pearl = types.SimpleNamespace(safes={FakeChain.GNOSIS: "0xpl"},
+                                      address="0xpe")
+        m._drain_master(qs_wallet=qs, pearl_wallet=pearl)
+        # Both rails attempted — Safe first (raised), EOA second (succeeded).
+        assert calls == [True, False]
+
+
+class TestRunModeB:
+    def test_dry_run_short_circuits(
+        self, orch: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        m, *_ = orch
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=tmp_path / "qs"),
+            pearl=detect.OperateStore(root=tmp_path / "pl"),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=True)
+        assert "[dry-run]" in capsys.readouterr().out
+
+    def test_happy_path(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        monkeypatch.setattr(m, "merge_service",
+                            lambda service, src, dest: types.SimpleNamespace())
+        drain_called = {"n": 0}
+        def fake_drain(**kw: Any) -> list:
+            drain_called["n"] += 1
+            return []   # empty failures = full success
+        monkeypatch.setattr(m, "_drain_master", fake_drain)
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: True)
+        rename_called = {"n": 0}
+        def fake_rename(src: Any) -> Path:
+            rename_called["n"] += 1
+            return src.root
+        monkeypatch.setattr(m, "rename_source_for_rollback", fake_rename)
+
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        assert drain_called["n"] == 1
+        assert rename_called["n"] == 1
+
+    def test_unmigratable_skips_drain(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        def boom(**kw: Any) -> None:
+            raise m._Unmigratable(
+                service_id="sc-aaa", chain="gnosis", reason="cannot unstake",
+            )
+        monkeypatch.setattr(m, "_migrate_one_service", boom)
+        called = {"drain": 0, "rename": 0}
+        monkeypatch.setattr(m, "_drain_master",
+                            lambda **kw: called.update(drain=called["drain"] + 1))
+        monkeypatch.setattr(m, "rename_source_for_rollback",
+                            lambda store: called.update(rename=called["rename"] + 1) or store.root)
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        assert called["drain"] == 0
+        # Nothing migrated AND incomplete -> never rename source.
+        assert called["rename"] == 0
+        out = capsys.readouterr().out
+        assert "Skipping the master-Safe" in out
+        assert "Migration incomplete" in out
+        assert "Source `.operate/` left in place" in out
+
+    def test_merge_service_oserror_aggregates_as_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`merge_service` runs AFTER on-chain ops. An OSError here would,
+        without the wrap in `_run_mode_b`, propagate past `except _Unmigratable`
+        and abort the whole batch with no aggregation. The fix converts to
+        `_Unmigratable(chain=None)` so the user gets a per-service summary
+        and the on-chain-committed-but-files-not-copied state is recorded."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        def boom_copy(service: Any, src: Any, dest: Any) -> None:
+            raise OSError(28, "no space left on device")
+        monkeypatch.setattr(m, "merge_service", boom_copy)
+        called = {"drain": 0, "rename": 0}
+        monkeypatch.setattr(m, "_drain_master",
+                            lambda **kw: called.update(drain=called["drain"] + 1))
+        monkeypatch.setattr(m, "rename_source_for_rollback",
+                            lambda store: called.update(rename=called["rename"] + 1) or store.root)
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        # Drain skipped (unmigratable present); rename skipped (incomplete).
+        assert called["drain"] == 0
+        assert called["rename"] == 0
+        out = capsys.readouterr().out
+        # User-facing message names the service and tells them what to do.
+        assert "filesystem copy failed" in out
+        assert "Manually copy" in out
+        assert "sc-aaa" in out
+
+    def test_merge_service_shutil_error_also_aggregates(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """shutil.Error (separate exception type from OSError — used for
+        copytree multi-error aggregation) is also caught."""
+        import shutil as _shutil
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        def boom_copy(service: Any, src: Any, dest: Any) -> None:
+            raise _shutil.Error([("a", "b", "permission denied")])
+        monkeypatch.setattr(m, "merge_service", boom_copy)
+        monkeypatch.setattr(m, "_drain_master", lambda **kw: [])
+        # Should not raise; drain/rename gating happens at the higher level.
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+
+    def test_drain_failure_blocks_rename(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """All services migrate but a drain fails -> source MUST NOT be renamed."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        monkeypatch.setattr(m, "merge_service",
+                            lambda service, src, dest: types.SimpleNamespace())
+        # Drain returns a non-empty failure list.
+        m_FakeChain = orch[1]
+        fake_failure = m._DrainFailure(
+            chain=m_FakeChain.GNOSIS, source_kind="Safe",
+            source_address="0xqs", reason="rpc timeout",
+        )
+        monkeypatch.setattr(m, "_drain_master", lambda **kw: [fake_failure])
+        rename_called = {"n": 0}
+        monkeypatch.setattr(m, "rename_source_for_rollback",
+                            lambda store: rename_called.update(n=rename_called["n"] + 1))
+        # Force yes_no="yes" so we'd rename if the orchestrator asked.
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: True)
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        assert rename_called["n"] == 0   # rename refused
+        out = capsys.readouterr().out
+        assert "Migration incomplete" in out
+        assert "rpc timeout" in out
+        assert "Source `.operate/` left in place" in out
+
+    def test_collects_chain_rpcs_for_drain(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Per-service chain_configs feed `chain_rpcs` so the drain step can
+        create Pearl Safes on chains it doesn't yet have."""
+        m, FakeChain, _ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        # Service with a real chain_config so the chain_rpcs map gets populated.
+        chain_config = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(token=1, multisig="0xms"),
+            ledger_config=types.SimpleNamespace(rpc="https://rpc.example/gnosis"),
+        )
+        ref = _fake_service(
+            "sc-aaa", name="A", agent_addresses=[], path=tmp_path,
+            chain_configs={"gnosis": chain_config},
+        )
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        monkeypatch.setattr(m, "merge_service",
+                            lambda service, src, dest: types.SimpleNamespace())
+        captured: dict = {}
+        def fake_drain(**kw: Any) -> list:
+            captured.update(kw)
+            return []
+        monkeypatch.setattr(m, "_drain_master", fake_drain)
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: False)
+        monkeypatch.setattr(m, "rename_source_for_rollback", lambda store: store.root)
+
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        assert captured["chain_rpcs"] == {FakeChain.GNOSIS: "https://rpc.example/gnosis"}
+
+    def test_chain_rpcs_conflict_warns_keeps_first(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Two services declaring different RPCs for the same chain: warn
+        loudly, keep the first deterministically. Catches a regression where
+        someone replaces `setdefault`-style first-wins with `=`-style last-wins
+        without a warning."""
+        m, FakeChain, _ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        # Two services on the same chain with DIFFERENT RPCs.
+        cc_a = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(token=1, multisig="0xms-a"),
+            ledger_config=types.SimpleNamespace(rpc="https://rpc.private/gnosis"),
+        )
+        cc_b = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(token=2, multisig="0xms-b"),
+            ledger_config=types.SimpleNamespace(rpc="https://rpc.public/gnosis"),
+        )
+        ref_a = _fake_service("sc-aaa", name="A", path=tmp_path,
+                              chain_configs={"gnosis": cc_a})
+        ref_b = _fake_service("sc-bbb", name="B", path=tmp_path,
+                              chain_configs={"gnosis": cc_b})
+
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        monkeypatch.setattr(m, "merge_service",
+                            lambda service, src, dest: types.SimpleNamespace())
+        captured: dict = {}
+        monkeypatch.setattr(m, "_drain_master",
+                            lambda **kw: captured.update(kw) or [])
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: False)
+        monkeypatch.setattr(m, "rename_source_for_rollback", lambda store: store.root)
+
+        m._run_mode_b(disc=d, services=[ref_a, ref_b], config_path=None, dry_run=False)
+
+        # First-wins (deterministic).
+        assert captured["chain_rpcs"][FakeChain.GNOSIS] == "https://rpc.private/gnosis"
+        # And the user is told.
+        out = capsys.readouterr().out
+        assert "different RPC" in out
+        assert "rpc.private" in out and "rpc.public" in out
+
+    def test_failed_load_aborts_before_any_action(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If `services()` dropped any malformed configs, refuse to migrate."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        qs_store = detect.OperateStore(root=qs_root)
+        pl_store = detect.OperateStore(root=pl_root)
+        d = detect.Discovery(quickstart=qs_store, pearl=pl_store, mode=detect.Mode.MERGE)
+        # Pretend the store had a malformed config that didn't load.
+        monkeypatch.setattr(qs_store.__class__, "failed_services",
+                            lambda self: [(qs_root / "services/sc-bad", RuntimeError("bad"))])
+        # Capture whether any wallet loading happens (it must not).
+        load_called = {"n": 0}
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: load_called.update(n=load_called["n"] + 1))
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(SystemExit):
+            m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        assert load_called["n"] == 0
+
+    def test_rename_declined(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"
+        pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: ("APP", "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        monkeypatch.setattr(m, "merge_service",
+                            lambda service, src, dest: types.SimpleNamespace())
+        monkeypatch.setattr(m, "_drain_master", lambda **kw: [])
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: False)
+        called = {"rename": 0}
+        monkeypatch.setattr(m, "rename_source_for_rollback",
+                            lambda store: called.update(rename=called["rename"] + 1))
+        m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+        assert called["rename"] == 0
+
+
+class TestFinalPrompt:
+    def test_complete_yes_branch(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        m, *_ = orch
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: True)
+        m._final_prompt(m.MigrationOutcome(migrated=(_fake_service("sc-aaa"),)))
+        out = capsys.readouterr().out
+        assert "different machine" in out.lower() or "Copy `~/.operate/`" in out
+
+    def test_complete_no_branch(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        m, *_ = orch
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: False)
+        m._final_prompt(m.MigrationOutcome(migrated=(_fake_service("sc-aaa"),)))
+        assert "Start Pearl" in capsys.readouterr().out
+
+    def test_no_default_arg_required(self, orch: Any) -> None:
+        """`_final_prompt` must require an explicit outcome — the previous
+        default-arg sentinel was a footgun (silent success on caller bugs)."""
+        m, *_ = orch
+        with pytest.raises(TypeError):
+            m._final_prompt()
+
+    def test_incomplete_skips_prompts_and_warns(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Partial migration: must NOT ask the 'different machine?' question
+        and must explicitly say the source is preserved."""
+        m, *_ = orch
+        # Track that yes_no is never called.
+        called = {"n": 0}
+        monkeypatch.setattr(m, "yes_no",
+                            lambda *a, **k: called.update(n=called["n"] + 1) or False)
+        outcome = m.MigrationOutcome(
+            unmigratable=(m._Unmigratable(
+                service_id="sc-aaa", chain="gnosis", reason="boom",
+            ),),
+        )
+        m._final_prompt(outcome)
+        out = capsys.readouterr().out
+        assert "Migration incomplete" in out
+        assert "Resolve the issues" in out
+        assert called["n"] == 0
+
+
+class TestMain:
+    def test_noop_returns_via_preflight(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        m, *_ = orch
+        store = tmp_path / ".operate"
+        store.mkdir()
+        monkeypatch.setattr(m, "discover", lambda quickstart_root, pearl_root: detect.Discovery(
+            quickstart=detect.OperateStore(root=store),
+            pearl=detect.OperateStore(root=store),
+            mode=detect.Mode.NOOP,
+        ))
+        with pytest.raises(SystemExit):
+            m.main([])
+
+    def test_discover_value_error_becomes_fatal(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Invariant violations from Discovery/__post_init__ surface via fatal()
+        instead of leaking a stacktrace to the user."""
+        m, *_ = orch
+        def boom(quickstart_root: Any, pearl_root: Any) -> Any:
+            raise ValueError("Discovery: stores share root /x but mode is FRESH_COPY")
+        monkeypatch.setattr(m, "discover", boom)
+        with pytest.raises(SystemExit):
+            m.main([])
+        # The fatal() output goes to stderr.
+        err = capsys.readouterr().err
+        assert "Discovery failed" in err
+
+    def test_fresh_copy_dry_run(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        m, *_ = orch
+        qs = detect.OperateStore(root=tmp_path / "qs")
+        pl = detect.OperateStore(root=tmp_path / "pl")
+        monkeypatch.setattr(m, "discover", lambda quickstart_root, pearl_root: detect.Discovery(
+            quickstart=qs, pearl=pl, mode=detect.Mode.FRESH_COPY,
+        ))
+        monkeypatch.setattr(m, "pearl_daemon_running", lambda: False)
+        monkeypatch.setattr(m, "docker_quickstart_containers", lambda: [])
+        called = {"a": 0, "fp": 0}
+        monkeypatch.setattr(m, "_run_mode_a", lambda disc, dry_run: called.update(a=called["a"] + 1))
+        monkeypatch.setattr(m, "_final_prompt", lambda **kw: called.update(fp=called["fp"] + 1))
+        rc = m.main(["--dry-run"])
+        assert rc == 0
+        assert called["a"] == 1
+        assert called["fp"] == 0  # dry-run skips final prompt
+
+    def test_merge_invokes_select_and_run_b(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        patch_service_load: dict[Path, Any],
+    ) -> None:
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        _write_service(qs_root, "sc-aaa", name="A")
+        patch_service_load[(qs_root / "services/sc-aaa").resolve()] = (
+            _fake_service("sc-aaa", name="A")
+        )
+        qs = detect.OperateStore(root=qs_root.resolve())
+        pl = detect.OperateStore(root=tmp_path / "pl/.operate")
+        monkeypatch.setattr(m, "discover", lambda quickstart_root, pearl_root: detect.Discovery(
+            quickstart=qs, pearl=pl, mode=detect.Mode.MERGE,
+        ))
+        monkeypatch.setattr(m, "pearl_daemon_running", lambda: False)
+        monkeypatch.setattr(m, "docker_quickstart_containers", lambda: [])
+        called = {"b": 0, "fp": 0, "outcome": None}
+        def fake_run_b(**kw: Any) -> Any:
+            called["b"] += 1
+            return m.MigrationOutcome(migrated=(_fake_service("sc-x"),))
+        monkeypatch.setattr(m, "_run_mode_b", fake_run_b)
+        def fake_final(outcome: Any = None) -> None:
+            called["fp"] += 1
+            called["outcome"] = outcome
+        monkeypatch.setattr(m, "_final_prompt", fake_final)
+        rc = m.main([])
+        assert rc == 0
+        assert called["b"] == 1
+        assert called["fp"] == 1
+        assert called["outcome"] is not None and called["outcome"].is_complete
+
+
+def test_orchestrator_module_is_runnable_as_script(
+    orch: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`if __name__ == "__main__"` block — execute via runpy with main mocked.
+
+    Uses `runpy.run_module(..., run_name="__main__")` so the guard executes
+    and the line gets covered. main() is stubbed to a noop returning 0.
+    """
+    import runpy
+
+    # `runpy.run_module(..., run_name="__main__")` re-executes the source in a
+    # fresh namespace, so we can't monkeypatch the cached module. Instead we
+    # stub `discover` so preflight short-circuits via NOOP -> SystemExit(0).
+    monkeypatch.setattr(sys, "argv", ["migrate_to_pearl"])
+    fake_store = detect.OperateStore(root=Path("/tmp"))
+    monkeypatch.setattr(
+        "scripts.pearl_migration.detect.discover",
+        lambda quickstart_root, pearl_root: detect.Discovery(
+            quickstart=fake_store, pearl=fake_store, mode=detect.Mode.NOOP,
+        ),
+    )
+    with pytest.raises(SystemExit):
+        runpy.run_module(
+            "scripts.pearl_migration.migrate_to_pearl",
+            run_name="__main__",
+        )

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -877,24 +877,15 @@ class TestFilesystemExtras:
         # Should be a no-op, no exceptions.
         filesystem.fix_root_ownership(store)
 
-    def test_fix_root_ownership_no_root_owned(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        (tmp_path / "services" / "sc-aaa" / "persistent_data").mkdir(parents=True)
-        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: False)
-        called: list[Any] = []
-        monkeypatch.setattr(filesystem.subprocess, "run",
-                            lambda *a, **k: called.append((a, k)))
-        store = detect.OperateStore(root=tmp_path)
-        filesystem.fix_root_ownership(store)
-        assert called == []
-
     def test_fix_root_ownership_runs_chown(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        # fix_root_ownership now always chowns each service dir (detection
+        # via Path.rglob is unreliable on Python 3.14 against trees the
+        # current user can't traverse, so unconditional chown is safer
+        # than risking a mid-copy permission denied).
         pdata = tmp_path / "services" / "sc-aaa" / "persistent_data"
         pdata.mkdir(parents=True)
-        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: True)
         invoked: list[list[str]] = []
         def fake_run(cmd: list[str], **kw: Any) -> Any:
             invoked.append(cmd)
@@ -909,7 +900,6 @@ class TestFilesystemExtras:
     ) -> None:
         pdata = tmp_path / "services" / "sc-aaa" / "persistent_data"
         pdata.mkdir(parents=True)
-        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: True)
         def fake_run(cmd: list[str], **kw: Any) -> Any:
             raise subprocess.CalledProcessError(1, cmd)
         monkeypatch.setattr(filesystem.subprocess, "run", fake_run)
@@ -930,7 +920,6 @@ class TestFilesystemExtras:
         outside = tmp_path / "elsewhere"
         outside.mkdir()
         (store_root / "services" / "sc-aaa").symlink_to(outside)
-        monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: True)
         store = detect.OperateStore(root=store_root.resolve())
         with pytest.raises(RuntimeError, match="not inside store root"):
             filesystem.fix_root_ownership(store)

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -1116,6 +1116,43 @@ class TestAlignQuickstartPassword:
         )
         assert qs_app.password == "new"
 
+    def test_skips_dotfiles_in_keys_dir(self, tmp_path: Path) -> None:
+        """macOS Finder writes `.DS_Store` into any browsed directory,
+        including `keys/`. It must be skipped — feeding it to
+        `_reencrypt_agent_key` would crash at `json.loads()` and abort
+        the rotation. Same goes for any other dotfile (editor swap,
+        `.git`, etc.) — real keys are named `0x{40-hex}` so a leading
+        dot never matches a legitimate keyfile.
+        """
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        keys_dir = operate_root / "keys"
+        wallets_dir.mkdir(parents=True)
+        keys_dir.mkdir()
+        (keys_dir / ".DS_Store").write_bytes(b"\x00\x01binary-junk")
+
+        qs_wallet = types.SimpleNamespace(
+            path=wallets_dir, update_password=lambda new: None,
+        )
+        qs_app = types.SimpleNamespace(
+            password="old",
+            keys_manager=types.SimpleNamespace(path=keys_dir, password="old"),
+        )
+        called: list[Any] = []
+        from unittest.mock import patch
+        with patch.object(
+            wallet_mod, "_reencrypt_agent_key",
+            lambda **kw: called.append(kw["key_path"]),
+        ):
+            wallet_mod.align_quickstart_password(
+                qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
+            )
+        assert called == [], (
+            "dotfiles must be skipped — got: " + repr(called)
+        )
+
     def test_old_password_captured_before_update_password(
         self, tmp_path: Path,
     ) -> None:
@@ -1266,6 +1303,32 @@ class TestFilesystemExtras:
         assert "indeterminate" in msg
         # Both chown attempts ran (no early-exit before the failure).
         assert len(seen) == 2
+
+    def test_fix_root_ownership_skips_non_service_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """macOS Finder writes a root-owned `.DS_Store` directly under
+        `services/` on some setups. It is not a service directory and
+        must not trigger a chown — otherwise users without passwordless
+        sudo hit a fatal `sudo -n` failure on a file that the migration
+        does not even copy. Same applies to any stray dotfile or
+        non-`sc-` directory.
+        """
+        services_dir = tmp_path / "services"
+        services_dir.mkdir()
+        (services_dir / "sc-aaa").mkdir()
+        (services_dir / ".DS_Store").write_text("junk")
+        (services_dir / "stray-dir").mkdir()
+        invoked_targets: list[str] = []
+        def fake_run(cmd: list[str], **kw: Any) -> Any:
+            invoked_targets.append(cmd[-1])
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+        monkeypatch.setattr(filesystem.subprocess, "run", fake_run)
+        store = detect.OperateStore(root=tmp_path.resolve())
+        filesystem.fix_root_ownership(store)
+        # Only the real service dir was chowned.
+        assert len(invoked_targets) == 1
+        assert invoked_targets[0].endswith("/sc-aaa")
 
     def test_fix_root_ownership_refuses_outside_store(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -921,16 +921,15 @@ class TestFilesystemExtras:
     def test_fix_root_ownership_refuses_outside_store(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Construct a service dir that is symlinked OUTSIDE the store.
+        # Construct a service dir whose entry under services/ is itself a
+        # symlink to a directory OUTSIDE the store. fix_root_ownership
+        # resolves the service dir and refuses if it escapes store root.
         store_root = tmp_path / "store"
         store_root.mkdir()
         (store_root / "services").mkdir()
-        outside = tmp_path / "elsewhere/persistent_data"
-        outside.mkdir(parents=True)
-        # Service dir contains a symlink to the outside persistent_data.
-        sdir = store_root / "services" / "sc-aaa"
-        sdir.mkdir()
-        (sdir / "persistent_data").symlink_to(outside)
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        (store_root / "services" / "sc-aaa").symlink_to(outside)
         monkeypatch.setattr(filesystem, "any_root_owned_under", lambda p: True)
         store = detect.OperateStore(root=store_root.resolve())
         with pytest.raises(RuntimeError, match="not inside store root"):

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -5898,7 +5898,7 @@ class TestFinalPrompt:
         m, *_ = orch
         monkeypatch.setattr(m, "yes_no", lambda *a, **k: False)
         m._final_prompt(m.MigrationOutcome(migrated=(_fake_service("sc-aaa"),)))
-        assert "Start Pearl" in capsys.readouterr().out
+        assert "Start the latest version of Pearl" in capsys.readouterr().out
 
     def test_no_default_arg_required(self, orch: Any) -> None:
         """`_final_prompt` must require an explicit outcome — the previous

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -9,6 +9,7 @@ keeps satisfying `--cov-fail-under=100`.
 from __future__ import annotations
 
 import json
+import os
 import socket
 import subprocess
 import sys
@@ -920,7 +921,7 @@ class TestAlignQuickstartPassword:
         )
         keys_manager = types.SimpleNamespace(path=keys_dir, password=old_pw)
         qs_app = types.SimpleNamespace(
-            password=old_pw, keys_manager=keys_manager,
+            password=old_pw, keys_manager=keys_manager, user_account=None,
         )
 
         wallet_mod.align_quickstart_password(
@@ -980,6 +981,7 @@ class TestAlignQuickstartPassword:
         qs_app = types.SimpleNamespace(
             password="old",
             keys_manager=types.SimpleNamespace(path=keys_dir, password="old"),
+            user_account=None,
         )
         with pytest.raises(RuntimeError, match="disk full"):
             wallet_mod.align_quickstart_password(
@@ -1045,6 +1047,7 @@ class TestAlignQuickstartPassword:
         qs_app = types.SimpleNamespace(
             password=old_pw,
             keys_manager=types.SimpleNamespace(path=keys_dir, password=old_pw),
+            user_account=None,
         )
         with pytest.raises(RuntimeError, match="io error mid-walk"):
             wallet_mod.align_quickstart_password(
@@ -1083,7 +1086,9 @@ class TestAlignQuickstartPassword:
         keys_manager = types.SimpleNamespace(
             path=operate_root / "absent_keys", password="old",
         )
-        qs_app = types.SimpleNamespace(password="old", keys_manager=keys_manager)
+        qs_app = types.SimpleNamespace(
+            password="old", keys_manager=keys_manager, user_account=None,
+        )
         wallet_mod.align_quickstart_password(
             qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
         )
@@ -1109,6 +1114,7 @@ class TestAlignQuickstartPassword:
         qs_app = types.SimpleNamespace(
             password="old",
             keys_manager=types.SimpleNamespace(path=keys_dir, password="old"),
+            user_account=None,
         )
         # Should not raise — subdir gets skipped silently.
         wallet_mod.align_quickstart_password(
@@ -1139,6 +1145,7 @@ class TestAlignQuickstartPassword:
         qs_app = types.SimpleNamespace(
             password="old",
             keys_manager=types.SimpleNamespace(path=keys_dir, password="old"),
+            user_account=None,
         )
         called: list[Any] = []
         from unittest.mock import patch
@@ -1173,6 +1180,7 @@ class TestAlignQuickstartPassword:
         qs_app: Any = types.SimpleNamespace(
             password="real-old",
             keys_manager=types.SimpleNamespace(path=keys_dir, password="real-old"),
+            user_account=None,
         )
         def mutate_password(new: str) -> None:
             qs_app.password = new
@@ -1196,6 +1204,119 @@ class TestAlignQuickstartPassword:
             "old_password must be captured BEFORE update_password rotates it; "
             f"got {captured_old}"
         )
+
+    def test_invokes_user_account_alignment_after_rotation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """After rotating the wallet+keys to Pearl's password,
+        `user.json` must be re-aligned. Without this, qs's `user.json`
+        still hashes the OLD pwd and middleware's
+        `ask_password_if_needed` would diverge from the freshly-rotated
+        wallet — re-introducing the same DecryptError-via-OnChainHelper
+        failure mode that the initial `_load_wallet` alignment fixes.
+        """
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        wallets_dir.mkdir(parents=True)
+
+        qs_wallet = types.SimpleNamespace(
+            path=wallets_dir, update_password=lambda new: None,
+        )
+        qs_app = types.SimpleNamespace(
+            password="old",
+            keys_manager=types.SimpleNamespace(
+                path=operate_root / "absent_keys", password="old",
+            ),
+            user_account=None,
+        )
+
+        align_calls: list[Any] = []
+        monkeypatch.setattr(
+            wallet_mod, "align_user_account_to_wallet",
+            lambda app: align_calls.append((app, app.password)),
+        )
+
+        wallet_mod.align_quickstart_password(
+            qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
+        )
+
+        assert align_calls == [(qs_app, "new")], (
+            "align_user_account_to_wallet must run AFTER qs_app.password is "
+            "rotated to Pearl's password — otherwise it would align "
+            "user.json to the now-stale qs password."
+        )
+
+    def test_alignment_failure_warns_about_keys_already_rotated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If `align_user_account_to_wallet` raises AFTER the wallet+keys
+        are already rotated, the warn message must NOT instruct the user
+        to restore from the snapshot — that would put wallet/keys back
+        to the old password while `qs_app.password` in-memory thinks
+        it's the new one. The alignment is OUTSIDE the snapshot try
+        for this reason; the message must explicitly tell the user not
+        to restore.
+        """
+        from scripts.pearl_migration import wallet as wallet_mod
+
+        operate_root = tmp_path / ".operate"
+        wallets_dir = operate_root / "wallets"
+        wallets_dir.mkdir(parents=True)
+
+        qs_wallet = types.SimpleNamespace(
+            path=wallets_dir, update_password=lambda new: None,
+        )
+        qs_app = types.SimpleNamespace(
+            password="old",
+            keys_manager=types.SimpleNamespace(
+                path=operate_root / "absent_keys", password="old",
+            ),
+            user_account=None,
+        )
+
+        warn_calls: list[str] = []
+        monkeypatch.setattr(wallet_mod, "warn", lambda msg: warn_calls.append(msg))
+
+        # Capture qs_app.password at the moment alignment fires. If
+        # `align_user_account_to_wallet` were ever moved back inside
+        # the snapshot try/except, this snapshot would still see "old"
+        # because the snapshot's exception handler short-circuits the
+        # rotation block before line 172's `qs_app.password = new`.
+        # Asserting "new" here is the structural proof that alignment
+        # runs AFTER the rotation, not during/before it — which is the
+        # entire reason the call was moved out in the first place.
+        password_at_alignment: list[str] = []
+
+        def fail_alignment(app: Any) -> None:
+            password_at_alignment.append(app.password)
+            raise OSError("disk full")
+        monkeypatch.setattr(
+            wallet_mod, "align_user_account_to_wallet", fail_alignment,
+        )
+
+        with pytest.raises(OSError, match="disk full"):
+            wallet_mod.align_quickstart_password(
+                qs_app=qs_app, qs_wallet=qs_wallet, new_password="new",
+            )
+
+        # Structural placement assertion: alignment ran on the
+        # post-rotation app state, not the pre-rotation one.
+        assert password_at_alignment == ["new"], (
+            f"alignment fired with qs_app.password={password_at_alignment!r}; "
+            "expected 'new' (placement: AFTER rotation, OUTSIDE snapshot try)"
+        )
+
+        # The warn must be the alignment-specific one (not the snapshot-
+        # recovery one), and must explicitly warn against restore.
+        assert any("user.json hash failed" in m for m in warn_calls), warn_calls
+        assert any("Do NOT restore" in m for m in warn_calls), warn_calls
+        # And must NOT print the snapshot-recovery `rm -rf wallets/ keys/`
+        # message — that'd point the user at the wrong recovery.
+        assert not any(
+            "Recover with: rm -rf" in m for m in warn_calls
+        ), warn_calls
 
 
 # ---------------------------------------------------------------------------
@@ -1462,17 +1583,21 @@ class TestPromptsExtras:
 # ---------------------------------------------------------------------------
 
 class TestStop:
-    def test_stop_via_middleware_calls_into_module(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        from scripts.pearl_migration import stop
-
+    @staticmethod
+    def _patch_middleware_stop(
+        monkeypatch: pytest.MonkeyPatch,
+        impl: Any,
+    ) -> dict[str, Any]:
+        """Stub `operate.quickstart.stop_service.stop_service` with `impl`."""
         called: dict[str, Any] = {}
         fake_quickstart = types.ModuleType("operate.quickstart")
         fake_stop = types.ModuleType("operate.quickstart.stop_service")
+
         def fake_stop_service(operate: Any, config_path: str) -> None:
             called["operate"] = operate
             called["config_path"] = config_path
+            impl(operate, config_path)
+
         fake_stop.stop_service = fake_stop_service  # type: ignore[attr-defined]
         operate_pkg = sys.modules.get("operate") or types.ModuleType("operate")
         monkeypatch.setitem(sys.modules, "operate", operate_pkg)
@@ -1480,9 +1605,123 @@ class TestStop:
         monkeypatch.setitem(
             sys.modules, "operate.quickstart.stop_service", fake_stop,
         )
+        return called
 
-        stop.stop_via_middleware(operate="OP", config_path="cfg.json")
-        assert called == {"operate": "OP", "config_path": "cfg.json"}
+    def test_stop_via_middleware_calls_into_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from scripts.pearl_migration import stop
+
+        op = types.SimpleNamespace(password="pw_wallet")
+        called = self._patch_middleware_stop(monkeypatch, lambda o, c: None)
+
+        stop.stop_via_middleware(operate=op, config_path="cfg.json")
+        assert called == {"operate": op, "config_path": "cfg.json"}
+
+    def test_stop_via_middleware_sets_unattended_env_then_restores(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Middleware's `ask_password_if_needed` would prompt
+        interactively for a password we already validated, then
+        overwrite `operate.password` with whatever the user types
+        (validated against `user.json`'s hash, not the wallet keyfile).
+        Plumb `OPERATE_PASSWORD` + `ATTENDED=false` so middleware's
+        `ask_or_get_from_env` reads our wallet-validated password from
+        the env and skips the prompt entirely. Restore the env after
+        so unattended mode doesn't leak into post-stop steps.
+        """
+        from scripts.pearl_migration import stop
+
+        op = types.SimpleNamespace(password="pw_wallet")
+        seen_env: dict[str, Any] = {}
+
+        def capture_env(o: Any, c: str) -> None:
+            seen_env["OPERATE_PASSWORD"] = os.environ.get("OPERATE_PASSWORD")
+            seen_env["ATTENDED"] = os.environ.get("ATTENDED")
+
+        self._patch_middleware_stop(monkeypatch, capture_env)
+        # Ensure clean env: no pre-existing values to surprise the test.
+        monkeypatch.delenv("OPERATE_PASSWORD", raising=False)
+        monkeypatch.delenv("ATTENDED", raising=False)
+
+        stop.stop_via_middleware(operate=op, config_path="cfg.json")
+
+        assert seen_env == {
+            "OPERATE_PASSWORD": "pw_wallet", "ATTENDED": "false",
+        }
+        # Env restored to "absent" after the call — middleware's
+        # unattended mode must not leak into anything else.
+        assert "OPERATE_PASSWORD" not in os.environ
+        assert "ATTENDED" not in os.environ
+
+    def test_stop_via_middleware_restores_preexisting_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the user already had `OPERATE_PASSWORD` / `ATTENDED` set
+        (e.g. running unattended via env), restore their original values
+        rather than deleting the env entries.
+        """
+        from scripts.pearl_migration import stop
+
+        op = types.SimpleNamespace(password="pw_wallet")
+        monkeypatch.setenv("OPERATE_PASSWORD", "user_pre_existing")
+        monkeypatch.setenv("ATTENDED", "true")
+
+        self._patch_middleware_stop(monkeypatch, lambda o, c: None)
+
+        stop.stop_via_middleware(operate=op, config_path="cfg.json")
+
+        assert os.environ["OPERATE_PASSWORD"] == "user_pre_existing"
+        assert os.environ["ATTENDED"] == "true"
+
+    def test_stop_via_middleware_restores_env_on_exception(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Env restoration must happen via `finally` even when middleware
+        raises — leaking unattended mode would silently degrade later
+        prompts (e.g. RPC re-entry) into "raise on missing env var"."""
+        from scripts.pearl_migration import stop
+
+        op = types.SimpleNamespace(password="pw_wallet")
+        monkeypatch.delenv("OPERATE_PASSWORD", raising=False)
+        monkeypatch.delenv("ATTENDED", raising=False)
+
+        def raising(o: Any, c: str) -> None:
+            raise RuntimeError("boom")
+
+        self._patch_middleware_stop(monkeypatch, raising)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            stop.stop_via_middleware(operate=op, config_path="cfg.json")
+        assert "OPERATE_PASSWORD" not in os.environ
+        assert "ATTENDED" not in os.environ
+
+    def test_stop_via_middleware_no_env_set_when_password_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If `operate.password` is `None` (caller didn't pre-validate),
+        don't fabricate an env var — let middleware's interactive
+        prompt run as designed (likely the create-new-user branch)."""
+        from scripts.pearl_migration import stop
+
+        op = types.SimpleNamespace(password=None)
+        seen_env: dict[str, Any] = {}
+
+        def capture_env(o: Any, c: str) -> None:
+            seen_env["OPERATE_PASSWORD"] = os.environ.get("OPERATE_PASSWORD")
+            seen_env["ATTENDED"] = os.environ.get("ATTENDED")
+
+        self._patch_middleware_stop(monkeypatch, capture_env)
+        monkeypatch.delenv("OPERATE_PASSWORD", raising=False)
+        monkeypatch.delenv("ATTENDED", raising=False)
+
+        stop.stop_via_middleware(operate=op, config_path="cfg.json")
+
+        assert seen_env == {"OPERATE_PASSWORD": None, "ATTENDED": None}
 
     def test_force_remove_known_containers_no_leftovers(
         self, monkeypatch: pytest.MonkeyPatch
@@ -2250,7 +2489,14 @@ class TestLoadWallet:
 
         fake_wallet = types.SimpleNamespace(name="loaded")
         fake_wm = types.SimpleNamespace(load=lambda lt: fake_wallet)
-        fake_app = types.SimpleNamespace(wallet_manager=fake_wm, password=None)
+        # `user_account=None` so the alignment helper short-circuits;
+        # the alignment behaviour itself is exercised in
+        # `TestAlignUserAccountToWallet`. Here we just want to assert
+        # `_load_wallet` calls it (next test) without diving into its
+        # internals.
+        fake_app = types.SimpleNamespace(
+            wallet_manager=fake_wm, password=None, user_account=None,
+        )
         operate_cli = sys.modules.setdefault("operate.cli", types.ModuleType("operate.cli"))
         operate_cli.OperateApp = lambda **kw: fake_app  # type: ignore[attr-defined]
         monkeypatch.setitem(sys.modules, "operate.cli", operate_cli)
@@ -2266,6 +2512,45 @@ class TestLoadWallet:
         assert wallet is fake_wallet
         assert app.password == "thepw"
         assert seen == ["wrong", "thepw"]
+
+    def test_invokes_user_account_alignment(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_load_wallet` must invoke `align_user_account_to_wallet`
+        right after building the app. Without this, a diverged
+        `user.json` would later silently route through middleware's
+        `ask_password_if_needed` and overwrite the wallet-validated
+        password — see `align_user_account_to_wallet` docstring.
+        """
+        m, *_ = orch
+        _write_wallet(tmp_path)
+        store = detect.OperateStore(root=tmp_path)
+
+        self._stub_master_wallet_manager(monkeypatch, valid_password="thepw")
+
+        fake_wallet = types.SimpleNamespace(name="loaded")
+        fake_wm = types.SimpleNamespace(load=lambda lt: fake_wallet)
+        fake_app = types.SimpleNamespace(
+            wallet_manager=fake_wm, password=None, user_account=None,
+        )
+        operate_cli = sys.modules.setdefault("operate.cli", types.ModuleType("operate.cli"))
+        operate_cli.OperateApp = lambda **kw: fake_app  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "operate.cli", operate_cli)
+
+        align_calls: list[Any] = []
+        monkeypatch.setattr(
+            m, "align_user_account_to_wallet",
+            lambda app: align_calls.append(app),
+        )
+        monkeypatch.setattr(m, "ask_password_validating", lambda **kw: "thepw")
+
+        m._load_wallet(store, "label")
+
+        assert align_calls == [fake_app], (
+            "_load_wallet must call align_user_account_to_wallet on the "
+            "freshly-built operate app so user.json/wallet pwd divergence "
+            "is corrected before any middleware op runs."
+        )
 
 
 class TestRunModeA:
@@ -2434,6 +2719,109 @@ class TestRunModeA:
         # Backup sibling exists
         siblings = list((tmp_path / "pl").iterdir())
         assert any(".bak." in p.name for p in siblings)
+
+
+class TestAlignUserAccountToWallet:
+    """`_align_user_account_to_wallet` force-rewrites `user.json`'s hash
+    to match `operate_app.password` so middleware's
+    `ask_password_if_needed` (validates against `user.json`) and our
+    own wallet validation (validates against the keyfile) accept the
+    same input. Without this, divergence between the two — observed in
+    the wild on a QA's install — silently routes through middleware,
+    overwrites `_wallet_manager.password`, and breaks every signing op
+    downstream.
+    """
+
+    @staticmethod
+    def _make_app(*, password: str | None, user_account: Any) -> Any:
+        return types.SimpleNamespace(password=password, user_account=user_account)
+
+    def test_noop_when_user_account_missing(self) -> None:
+        """No `user.json` → middleware will create one in
+        `ask_password_if_needed`'s create-new branch using the
+        `OPERATE_PASSWORD` env var we plumb in `stop_via_middleware`."""
+        from scripts.pearl_migration.wallet import (
+            align_user_account_to_wallet,
+        )
+
+        app = self._make_app(password="pw_wallet", user_account=None)
+        align_user_account_to_wallet(app)
+        # Nothing to assert beyond "didn't crash on None".
+
+    def test_raises_when_password_unset(self) -> None:
+        """`password is None` only fires on a programming bug — every
+        production caller establishes the wallet password before
+        invoking alignment. Raise rather than warn-and-continue: a
+        silent skip would leave `user.json` diverged and resurface as
+        the original "Cannot load private key" failure deep in
+        middleware, which is exactly the regression this helper is
+        meant to prevent.
+        """
+        from scripts.pearl_migration.wallet import (
+            align_user_account_to_wallet,
+        )
+
+        forced: dict[str, Any] = {}
+        ua = types.SimpleNamespace(
+            is_valid=lambda pw: False,
+            force_update=lambda pw: forced.setdefault("called_with", pw),
+        )
+        app = self._make_app(password=None, user_account=ua)
+
+        with pytest.raises(AssertionError, match="programming error"):
+            align_user_account_to_wallet(app)
+        assert forced == {}, "force_update must NOT run when password is None"
+
+    def test_noop_when_already_aligned(self) -> None:
+        """Common case: `user.json` already validates the wallet password.
+        Calling `force_update` would be a wasted argon2 hash + disk write."""
+        from scripts.pearl_migration.wallet import (
+            align_user_account_to_wallet,
+        )
+
+        forced: dict[str, Any] = {}
+
+        def force_update(pw: str) -> None:
+            forced["called_with"] = pw
+
+        ua = types.SimpleNamespace(
+            is_valid=lambda pw: pw == "pw_wallet",
+            force_update=force_update,
+        )
+        app = self._make_app(password="pw_wallet", user_account=ua)
+
+        align_user_account_to_wallet(app)
+        assert forced == {}
+
+    def test_force_updates_when_diverged(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Diverged install: `user.json`'s hash is for `pw_user`, wallet
+        is for `pw_wallet`. After alignment `force_update(pw_wallet)`
+        is called and the user-visible info line names the action so a
+        QA reading the log knows their `user.json` was rewritten.
+        """
+        from scripts.pearl_migration.wallet import (
+            align_user_account_to_wallet,
+        )
+
+        forced: dict[str, Any] = {}
+
+        def force_update(pw: str) -> None:
+            forced["called_with"] = pw
+
+        ua = types.SimpleNamespace(
+            is_valid=lambda pw: pw == "pw_user",
+            force_update=force_update,
+        )
+        app = self._make_app(password="pw_wallet", user_account=ua)
+
+        align_user_account_to_wallet(app)
+
+        assert forced == {"called_with": "pw_wallet"}
+        out = capsys.readouterr().out
+        assert "user.json password" in out
+        assert "aligning" in out.lower()
 
 
 class TestFormatExcChain:
@@ -4713,7 +5101,9 @@ class TestRunModeB:
         monkeypatch.setattr(
             m, "_load_wallet",
             lambda store, label: (
-                types.SimpleNamespace(password=next(passwords)), "WALLET",
+                types.SimpleNamespace(
+                    password=next(passwords), user_account=None,
+                ), "WALLET",
             ),
         )
         align_calls: list[dict[str, Any]] = []
@@ -4754,7 +5144,9 @@ class TestRunModeB:
         monkeypatch.setattr(
             m, "_load_wallet",
             lambda store, label: (
-                types.SimpleNamespace(password=next(passwords)), "WALLET",
+                types.SimpleNamespace(
+                    password=next(passwords), user_account=None,
+                ), "WALLET",
             ),
         )
         align_called = {"n": 0}
@@ -4767,6 +5159,85 @@ class TestRunModeB:
         with pytest.raises(SystemExit):
             m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
         assert align_called["n"] == 0
+
+    def test_password_align_failure_fatals_with_recovery_message(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """If `align_quickstart_password` raises (e.g. disk-full mid
+        rotation, or `force_update` fails on user.json after rotation),
+        `_run_mode_b` must convert the exception into `fatal(...)` with
+        a recovery hint — letting it propagate as a raw traceback would
+        bury the specific `warn` printed inside `align_quickstart_password`
+        that tells the user which recovery path applies.
+        """
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"; qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"; pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        passwords = iter(["qs-pw", "pearl-pw"])
+        monkeypatch.setattr(
+            m, "_load_wallet",
+            lambda store, label: (
+                types.SimpleNamespace(
+                    password=next(passwords), user_account=None,
+                ), "WALLET",
+            ),
+        )
+
+        def boom(**kw: Any) -> None:
+            raise OSError("disk full")
+        monkeypatch.setattr(m, "align_quickstart_password", boom)
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: True)
+
+        with pytest.raises(SystemExit):
+            m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
+
+        out = capsys.readouterr()
+        combined = out.out + out.err
+        assert "password alignment failed" in combined, combined
+        assert "disk full" in combined, combined
+        assert "nothing on-chain has changed" in combined, combined
+
+    def test_password_align_failure_does_not_swallow_programming_bugs(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`_reraise_if_programming_bug` must run before `fatal(...)`
+        so a `TypeError` / `AttributeError` from a middleware refactor
+        surfaces as a real traceback, not as a `fatal(...)` clean exit
+        that hides the bug under a "user error" framing.
+        """
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"; qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"; pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        passwords = iter(["qs-pw", "pearl-pw"])
+        monkeypatch.setattr(
+            m, "_load_wallet",
+            lambda store, label: (
+                types.SimpleNamespace(
+                    password=next(passwords), user_account=None,
+                ), "WALLET",
+            ),
+        )
+
+        def attribute_bug(**kw: Any) -> None:
+            raise AttributeError("middleware refactor: .password no longer exists")
+        monkeypatch.setattr(m, "align_quickstart_password", attribute_bug)
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: True)
+
+        with pytest.raises(AttributeError, match="middleware refactor"):
+            m._run_mode_b(disc=d, services=[ref], config_path=None, dry_run=False)
 
     def test_dry_run_short_circuits(
         self, orch: Any, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -4796,7 +5267,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -4833,7 +5304,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         def boom(**kw: Any) -> None:
             raise m._Unmigratable(
@@ -4875,7 +5346,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         def boom_copy(service: Any, src: Any, dest: Any) -> None:
@@ -4914,7 +5385,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         def boom_copy(service: Any, src: Any, dest: Any) -> None:
@@ -4941,7 +5412,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -4990,7 +5461,7 @@ class TestRunModeB:
             chain_configs={"gnosis": chain_config},
         )
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -5039,7 +5510,7 @@ class TestRunModeB:
                               chain_configs={"gnosis": cc_b})
 
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",
@@ -5098,7 +5569,7 @@ class TestRunModeB:
         )
         ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
         monkeypatch.setattr(m, "_load_wallet",
-                            lambda store, label: (types.SimpleNamespace(password="pw"), "WALLET"))
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
         monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
         monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
         monkeypatch.setattr(m, "merge_service",

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -473,6 +473,31 @@ class TestStatusOSChecks:
         monkeypatch.setattr(status.subprocess, "run", lambda *a, **k: completed)
         assert status.docker_quickstart_containers() == ["abci0", "node0"]
 
+    def test_docker_quickstart_containers_matches_per_service_substrings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Container names are `{service_name_clean}_abci_{idx}` and
+        `{service_name_clean}_tm_{idx}` per `autonomy.deploy.base`. Exact-set
+        matching against the literal fragments would silently skip these
+        per-service variants (`trader_abci_0`, `meme_factory_tm_0`, ...) and
+        let the migration race a still-running deployment. Substring matching
+        on `_abci_0` / `_tm_0` catches them all."""
+        completed = subprocess.CompletedProcess(
+            args=[], returncode=0,
+            stdout=(
+                "trader_abci_0\n"
+                "trader_tm_0\n"
+                "meme_factory_abci_0\n"
+                "unrelated_postgres\n"
+            ),
+        )
+        monkeypatch.setattr(status.subprocess, "run", lambda *a, **k: completed)
+        assert status.docker_quickstart_containers() == [
+            "meme_factory_abci_0",
+            "trader_abci_0",
+            "trader_tm_0",
+        ]
+
     def test_docker_quickstart_containers_handles_missing_docker(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -4757,6 +4782,41 @@ class TestMigrateOneService:
         assert "fully migrated: 4 service(s)" in out
         assert "Migration incomplete" not in out
 
+    def test_print_summary_subset_only_shows_subset_note(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the only reason for incompleteness is a subset selection
+        (no unmigratable, no drain failures), the summary surfaces the
+        dedicated 'subset migration:' note so the user understands
+        precisely why drain was skipped."""
+        m, *_ = orch
+        outcome = m.MigrationOutcome(
+            migrated=tuple(_fake_service(f"sc-{i}") for i in range(2)),
+            subset_selected=True,
+        )
+        m._print_migration_summary(outcome)
+        out = capsys.readouterr().out
+        assert "Migration incomplete" in out
+        assert "subset migration:" in out
+        assert "drains were skipped" in out
+
+    def test_print_summary_subset_with_unmigratable_omits_subset_note(
+        self, orch: Any, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Subset note is suppressed when there's also an unmigratable list
+        — stacking 're-run for the rest' on top of 're-run after fixing
+        the failure' would muddle the user's next action."""
+        m, *_ = orch
+        outcome = m.MigrationOutcome(
+            unmigratable=(m._Unmigratable(
+                service_id="sc-aaa", chain="gnosis", reason="boom",
+            ),),
+            subset_selected=True,
+        )
+        m._print_migration_summary(outcome)
+        out = capsys.readouterr().out
+        assert "subset migration:" not in out
+
     def test_print_summary_formats_each_failure_line(
         self, orch: Any, capsys: pytest.CaptureFixture[str],
     ) -> None:
@@ -5585,6 +5645,71 @@ class TestRunModeB:
         assert drain_called["n"] == 1
         assert rename_called["n"] == 1
 
+    def test_subset_selection_skips_drain_and_rename(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """`subset_selected=True` (user picked a single service from many,
+        or passed `--quickstart-config`) must skip the master-Safe and
+        master-EOA drains so the unselected services keep their shared
+        gas funds, and must NOT rename the source `.operate/` because
+        the unselected services still live there."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"; qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"; pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        monkeypatch.setattr(m, "_load_wallet",
+                            lambda store, label: (types.SimpleNamespace(password="pw", user_account=None), "WALLET"))
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        monkeypatch.setattr(m, "_migrate_one_service", lambda **kw: None)
+        monkeypatch.setattr(m, "merge_service",
+                            lambda service, src, dest: types.SimpleNamespace())
+        called = {"drain": 0, "rename": 0}
+        monkeypatch.setattr(m, "_drain_master",
+                            lambda **kw: called.update(drain=called["drain"] + 1) or [])
+        monkeypatch.setattr(m, "rename_source_for_rollback",
+                            lambda store: called.update(rename=called["rename"] + 1) or store.root)
+        monkeypatch.setattr(m, "yes_no", lambda *a, **k: True)
+
+        outcome = m._run_mode_b(
+            disc=d, services=[ref], config_path=None, dry_run=False,
+            subset_selected=True,
+        )
+
+        assert called["drain"] == 0
+        assert called["rename"] == 0
+        assert outcome.subset_selected is True
+        assert outcome.is_complete is False
+        out = capsys.readouterr().out
+        assert "Only a subset of the quickstart's services was migrated" in out
+        assert "subset migration:" in out
+        assert "remaining services still live in the source" in out
+
+    def test_subset_selection_dry_run_records_subset_flag(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dry-run must still surface `subset_selected` so the caller can
+        skip the post-run prompts even when no on-chain work happened."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"; qs_root.mkdir(parents=True)
+        pl_root = tmp_path / "pl/.operate"; pl_root.mkdir(parents=True)
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root),
+            pearl=detect.OperateStore(root=pl_root),
+            mode=detect.Mode.MERGE,
+        )
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        outcome = m._run_mode_b(
+            disc=d, services=[ref], config_path=None, dry_run=True,
+            subset_selected=True,
+        )
+        assert outcome.subset_selected is True
+
     def test_unmigratable_skips_drain(
         self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
@@ -5927,6 +6052,31 @@ class TestFinalPrompt:
         out = capsys.readouterr().out
         assert "Migration incomplete" in out
         assert "Resolve the issues" in out
+        assert called["n"] == 0
+
+    def test_subset_selection_uses_dedicated_message(
+        self, orch: Any, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Subset-only incompleteness gets its own message — phrasing
+        the same situation as a generic 'Migration incomplete — Resolve
+        the issues' would be misleading because the user intentionally
+        chose to migrate part of the quickstart."""
+        m, *_ = orch
+        called = {"n": 0}
+        monkeypatch.setattr(m, "yes_no",
+                            lambda *a, **k: called.update(n=called["n"] + 1) or False)
+        outcome = m.MigrationOutcome(
+            migrated=(_fake_service("sc-aaa"),),
+            subset_selected=True,
+        )
+        m._final_prompt(outcome)
+        out = capsys.readouterr().out
+        assert "Selected services migrated" in out
+        assert "remaining services left in source" in out
+        assert "re-run `migrate_to_pearl.sh`" in out
+        # Don't ask the "different machine?" question — copying Pearl's
+        # half-state to another machine without the source is incoherent.
         assert called["n"] == 0
 
 

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -2436,6 +2436,98 @@ class TestRunModeA:
         assert any(".bak." in p.name for p in siblings)
 
 
+class TestFormatExcChain:
+    """`_format_exc_chain` surfaces the deepest distinct chained cause.
+
+    Middleware wraps low-level errors (e.g. `KeyIsIncorrect` /
+    `DecryptError` carrying the keyfile path and reason) in generic
+    `click.ClickException`s ("Cannot load private key" with no detail).
+    Without the chain rendering, `_Unmigratable.reason` shows only the
+    generic message and there's no way for the user to tell wrong-pwd
+    from malformed file from missing path.
+    """
+
+    def test_returns_outer_when_no_chain(self) -> None:
+        from scripts.pearl_migration import migrate_to_pearl as m
+
+        assert m._format_exc_chain(RuntimeError("bare")) == "bare"
+
+    def test_appends_explicit_cause(self) -> None:
+        from scripts.pearl_migration import migrate_to_pearl as m
+
+        try:
+            try:
+                raise ValueError("MAC mismatch")
+            except ValueError as inner:
+                raise RuntimeError("Cannot load private key") from inner
+        except RuntimeError as exc:
+            rendered = m._format_exc_chain(exc)
+        assert rendered == (
+            "Cannot load private key (caused by ValueError: MAC mismatch)"
+        )
+
+    def test_falls_back_to_implicit_context(self) -> None:
+        """When the outer raise is a bare `raise NewExc(...)` inside an
+        `except`, Python sets `__context__` (not `__cause__`). We must
+        still surface that context so library code that doesn't bother
+        with `from e` still produces useful diagnostics.
+        """
+        from scripts.pearl_migration import migrate_to_pearl as m
+
+        try:
+            try:
+                raise ValueError("inner")
+            except ValueError:
+                raise RuntimeError("outer")  # implicit context, no `from`
+        except RuntimeError as exc:
+            rendered = m._format_exc_chain(exc)
+        assert rendered == "outer (caused by ValueError: inner)"
+
+    def test_skips_cause_with_identical_string(self) -> None:
+        """If the outer and inner stringify the same, repeating "(caused
+        by ...)" is noise. Walk past it to the next distinct cause if any.
+        """
+        from scripts.pearl_migration import migrate_to_pearl as m
+
+        try:
+            try:
+                try:
+                    raise KeyError("file_not_found")
+                except KeyError as a:
+                    raise ValueError("same") from a
+            except ValueError as b:
+                raise RuntimeError("same") from b
+        except RuntimeError as exc:
+            rendered = m._format_exc_chain(exc)
+        # Both 'same' layers are skipped; deepest distinct cause is the KeyError.
+        # Python repr's KeyError str adds quotes, hence "'file_not_found'".
+        assert rendered == "same (caused by KeyError: 'file_not_found')"
+
+    def test_returns_outer_when_chain_entirely_redundant(self) -> None:
+        """If every chained cause stringifies the same as the outer, we
+        return just the outer string — no useful diagnostic to add."""
+        from scripts.pearl_migration import migrate_to_pearl as m
+
+        try:
+            try:
+                raise ValueError("dup")
+            except ValueError as a:
+                raise RuntimeError("dup") from a
+        except RuntimeError as exc:
+            rendered = m._format_exc_chain(exc)
+        assert rendered == "dup"
+
+    def test_handles_self_referential_cause(self) -> None:
+        """Defensive: a malformed library could set __cause__ to self
+        (or a cycle). Walking blindly would loop forever. The `seen`
+        check should bail out cleanly."""
+        from scripts.pearl_migration import migrate_to_pearl as m
+
+        exc = RuntimeError("loop")
+        exc.__cause__ = exc  # type: ignore[assignment]
+        assert m._format_exc_chain(exc) == "loop"
+
+
 class TestStepTerminate:
     """Direct unit tests for `_step_terminate` — narrows the test surface
     so a step-helper signature regression is caught locally rather than

--- a/tests/test_scripts/test_pearl_migration.py
+++ b/tests/test_scripts/test_pearl_migration.py
@@ -1499,6 +1499,120 @@ class TestFilesystemExtras:
             pytest.fail("MissingAgentKey must be an OSError subclass")
 
 
+class TestResetServicesStakingToNoStaking:
+    """Mode A's equivalent of the in-memory reset that Mode B does via
+    `service.store()` inside `_migrate_one_service`. Both modes must
+    leave Pearl with `staking_program_id = no_staking` so it doesn't
+    re-apply quickstart's staking template post-migration. Implementation
+    reuses `OperateStore.services()` + `Service.store()` — same path Mode B
+    takes — rather than custom JSON munging, so all schema migrations and
+    atomic-write semantics stay in middleware code."""
+
+    def _fake_svc(
+        self,
+        sid: str,
+        *,
+        programs: dict[str, str],
+        store_calls: list[str],
+    ) -> Any:
+        chain_configs = {
+            chain: types.SimpleNamespace(
+                chain_data=types.SimpleNamespace(
+                    user_params=types.SimpleNamespace(
+                        staking_program_id=program,
+                    ),
+                ),
+            )
+            for chain, program in programs.items()
+        }
+        svc = types.SimpleNamespace(
+            service_config_id=sid,
+            chain_configs=chain_configs,
+        )
+        svc.store = lambda: store_calls.append(sid)
+        return svc
+
+    def test_rewrites_every_chain_and_calls_store_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        store_calls: list[str] = []
+        svc = self._fake_svc(
+            "sc-aaa",
+            programs={"gnosis": "qs_alpha", "optimism": "qs_beta"},
+            store_calls=store_calls,
+        )
+        store = detect.OperateStore(root=tmp_path)
+        monkeypatch.setattr(
+            detect.OperateStore, "services", lambda self: [svc],
+        )
+        updated = filesystem.reset_services_staking_to_no_staking(store)
+        assert updated == ["sc-aaa"]
+        for chain_config in svc.chain_configs.values():
+            assert (
+                chain_config.chain_data.user_params.staking_program_id
+                == "no_staking"
+            )
+        assert store_calls == ["sc-aaa"], "Service.store() called once per service"
+
+    def test_already_no_staking_is_noop_and_skips_store(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Re-running a migration must not write already-`no_staking`
+        configs — that would touch the file's mtime for no reason and
+        thrash backup/sync tooling."""
+        store_calls: list[str] = []
+        svc = self._fake_svc(
+            "sc-aaa",
+            programs={"gnosis": "no_staking"},
+            store_calls=store_calls,
+        )
+        monkeypatch.setattr(
+            detect.OperateStore, "services", lambda self: [svc],
+        )
+        updated = filesystem.reset_services_staking_to_no_staking(
+            detect.OperateStore(root=tmp_path),
+        )
+        assert updated == []
+        assert store_calls == []
+
+    def test_partial_reset_when_some_chains_already_no_staking(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A service spanning multiple chains where one is already
+        `no_staking` and another is not still triggers `store()` — the
+        single un-reset chain is enough to require a write."""
+        store_calls: list[str] = []
+        svc = self._fake_svc(
+            "sc-mixed",
+            programs={"gnosis": "no_staking", "optimism": "qs_beta"},
+            store_calls=store_calls,
+        )
+        monkeypatch.setattr(
+            detect.OperateStore, "services", lambda self: [svc],
+        )
+        updated = filesystem.reset_services_staking_to_no_staking(
+            detect.OperateStore(root=tmp_path),
+        )
+        assert updated == ["sc-mixed"]
+        assert store_calls == ["sc-mixed"]
+        # Both chains end up `no_staking` regardless of pre-state.
+        for chain_config in svc.chain_configs.values():
+            assert (
+                chain_config.chain_data.user_params.staking_program_id
+                == "no_staking"
+            )
+
+    def test_returns_empty_when_no_services(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            detect.OperateStore, "services", lambda self: [],
+        )
+        assert filesystem.reset_services_staking_to_no_staking(
+            detect.OperateStore(root=tmp_path),
+        ) == []
+
+
 # ---------------------------------------------------------------------------
 # prompts.py — extras
 # ---------------------------------------------------------------------------
@@ -2693,6 +2807,56 @@ class TestRunModeA:
         with pytest.raises(SystemExit):
             m._run_mode_a(disc=d, dry_run=False)
 
+    def test_real_run_invokes_staking_reset_against_dest_store(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Mode A (no on-chain step) MUST also leave Pearl with
+        `staking_program_id = no_staking` — symmetric with Mode B's
+        in-memory `service.store()` reset. Verifies wiring: the helper
+        is called against an `OperateStore` rooted at the destination,
+        AFTER `fresh_copy_store` and BEFORE `rename_source_for_rollback`
+        (so the helper sees the freshly-copied dest, and the soon-to-be-
+        renamed source stays an untouched rollback)."""
+        m, *_ = orch
+        qs_root = tmp_path / "qs/.operate"
+        _write_service(qs_root, "sc-aaa", agent_addresses=["0xa"])
+        _write_key(qs_root, "0xa")
+        _write_wallet(qs_root)
+        pl_root = tmp_path / "pl/.operate"
+        d = detect.Discovery(
+            quickstart=detect.OperateStore(root=qs_root.resolve()),
+            pearl=detect.OperateStore(root=pl_root.resolve()),
+            mode=detect.Mode.FRESH_COPY,
+        )
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "fix_root_ownership", lambda store: None)
+        # Capture call ordering: the helper must run AFTER the copy
+        # (so dest exists) and BEFORE the source rename (so source is
+        # still at qs_root for any subsequent cleanup).
+        events: list[tuple[str, Any]] = []
+        original_copy = m.fresh_copy_store
+        def spy_copy(src: Any, dest: Path) -> None:
+            events.append(("copy", dest))
+            return original_copy(src, dest)
+        def spy_reset(store: Any) -> list[str]:
+            events.append(("reset", store.root))
+            assert pl_root.resolve().exists(), "reset must run after copy"
+            return ["sc-aaa"]
+        original_rename = m.rename_source_for_rollback
+        def spy_rename(src: Any) -> Path:
+            events.append(("rename", src.root))
+            return original_rename(src)
+        monkeypatch.setattr(m, "fresh_copy_store", spy_copy)
+        monkeypatch.setattr(m, "reset_services_staking_to_no_staking", spy_reset)
+        monkeypatch.setattr(m, "rename_source_for_rollback", spy_rename)
+
+        m._run_mode_a(disc=d, dry_run=False)
+
+        kinds = [e[0] for e in events]
+        assert kinds == ["copy", "reset", "rename"]
+        # Helper was handed an OperateStore rooted at the destination.
+        assert events[1][1] == pl_root.resolve()
+
     def test_real_run_backs_up_existing_empty_pearl(
         self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
@@ -3550,12 +3714,24 @@ class TestMigrateOneService:
     def _make_service_obj(
         self, fake_chain_cls: Any, *, multisig: str = "0xms", token: int = 7,
     ) -> Any:
-        chain_data = types.SimpleNamespace(token=token, multisig=multisig)
+        # `user_params` and `store` are required by the post-loop staking
+        # reset in `_migrate_one_service`; pre-populating them with a
+        # non-`no_staking` id lets tests assert the reset actually fired.
+        chain_data = types.SimpleNamespace(
+            token=token,
+            multisig=multisig,
+            user_params=types.SimpleNamespace(
+                staking_program_id="quickstart_beta",
+            ),
+        )
         ledger_config = types.SimpleNamespace(rpc="http://rpc")
         chain_config = types.SimpleNamespace(
             chain_data=chain_data, ledger_config=ledger_config,
         )
-        return types.SimpleNamespace(chain_configs={"gnosis": chain_config})
+        return types.SimpleNamespace(
+            chain_configs={"gnosis": chain_config},
+            store=lambda: None,
+        )
 
     def _setup_manager(
         self, FakeChain: Any, FakeOnChainState: Any,
@@ -3906,15 +4082,22 @@ class TestMigrateOneService:
         m, FakeChain, FakeOnChainState = orch
         # Two distinct chain_configs, distinguished by RPC.
         cc_g = types.SimpleNamespace(
-            chain_data=types.SimpleNamespace(token=1, multisig="0xms-g"),
+            chain_data=types.SimpleNamespace(
+                token=1, multisig="0xms-g",
+                user_params=types.SimpleNamespace(staking_program_id="qsp"),
+            ),
             ledger_config=types.SimpleNamespace(rpc="https://rpc.example/gnosis"),
         )
         cc_o = types.SimpleNamespace(
-            chain_data=types.SimpleNamespace(token=2, multisig="0xms-o"),
+            chain_data=types.SimpleNamespace(
+                token=2, multisig="0xms-o",
+                user_params=types.SimpleNamespace(staking_program_id="qsp"),
+            ),
             ledger_config=types.SimpleNamespace(rpc="https://rpc.example/optimism"),
         )
         svc_obj = types.SimpleNamespace(
             chain_configs={"gnosis": cc_g, "optimism": cc_o},
+            store=lambda: None,
         )
 
         # Record which ledger_config each manager.get_eth_safe_tx_builder
@@ -4003,15 +4186,22 @@ class TestMigrateOneService:
         guard, leaving the late-binding risk on steps 2/3 unverified."""
         m, FakeChain, FakeOnChainState = orch
         cc_g = types.SimpleNamespace(
-            chain_data=types.SimpleNamespace(token=1, multisig="0xms-g"),
+            chain_data=types.SimpleNamespace(
+                token=1, multisig="0xms-g",
+                user_params=types.SimpleNamespace(staking_program_id="qsp"),
+            ),
             ledger_config=types.SimpleNamespace(rpc="https://rpc.example/gnosis"),
         )
         cc_o = types.SimpleNamespace(
-            chain_data=types.SimpleNamespace(token=2, multisig="0xms-o"),
+            chain_data=types.SimpleNamespace(
+                token=2, multisig="0xms-o",
+                user_params=types.SimpleNamespace(staking_program_id="qsp"),
+            ),
             ledger_config=types.SimpleNamespace(rpc="https://rpc.example/optimism"),
         )
         svc_obj = types.SimpleNamespace(
             chain_configs={"gnosis": cc_g, "optimism": cc_o},
+            store=lambda: None,
         )
 
         # Each call to get_eth_safe_tx_builder gets a fresh ledger handle
@@ -4629,6 +4819,113 @@ class TestMigrateOneService:
             config_path=None,
         )
         assert called == []  # config_path None bypasses stop_via_middleware
+
+    def test_resets_staking_program_id_to_no_staking_after_success(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """After all on-chain steps succeed, every chain's
+        `user_params.staking_program_id` is pinned to `no_staking` and the
+        update is persisted via `service.store()` — so Pearl reads the
+        post-migration on-chain reality (PRE_REGISTRATION + Pearl-owned
+        NFT) instead of inheriting quickstart's staking template."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+
+        # Replace the auto-built single-chain svc_obj with a two-chain one
+        # so we can assert ALL chains get reset, not just the first.
+        cc_g = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(
+                token=1, multisig="0xms-g",
+                user_params=types.SimpleNamespace(staking_program_id="qsp_g"),
+            ),
+            ledger_config=types.SimpleNamespace(rpc="http://rpc/g"),
+        )
+        cc_o = types.SimpleNamespace(
+            chain_data=types.SimpleNamespace(
+                token=2, multisig="0xms-o",
+                user_params=types.SimpleNamespace(staking_program_id="qsp_o"),
+            ),
+            ledger_config=types.SimpleNamespace(rpc="http://rpc/o"),
+        )
+        store_calls: list[Any] = []
+        svc_obj = types.SimpleNamespace(
+            chain_configs={"gnosis": cc_g, "optimism": cc_o},
+            store=lambda: store_calls.append(True),
+        )
+        manager.load = lambda service_config_id: svc_obj  # type: ignore[attr-defined]
+        # Two chains -> the autouse stub returns PRE_REGISTRATION on the
+        # second probe per chain; we need 4 entries total so terminate is
+        # skipped on both chains.
+        manager._get_on_chain_state = (  # type: ignore[attr-defined]
+            lambda s, c: FakeOnChainState.PRE_REGISTRATION
+        )
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        # NFT already on Pearl, Safe owner already swapped — keeps the
+        # test focused on the post-loop staking reset, not on-chain branches.
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl"])
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        m._migrate_one_service(
+            svc=ref, qs_app=qs_app,
+            qs_wallet=types.SimpleNamespace(
+                crypto="CR", address="0xqs_eoa",
+                ledger_api=lambda **kw: object(),
+                safes={FakeChain.GNOSIS: "0xqs", FakeChain.OPTIMISM: "0xqs"},
+            ),
+            pearl_wallet=types.SimpleNamespace(
+                safes={FakeChain.GNOSIS: "0xpl", FakeChain.OPTIMISM: "0xpl"},
+            ),
+            config_path=None,
+        )
+        assert cc_g.chain_data.user_params.staking_program_id == "no_staking"
+        assert cc_o.chain_data.user_params.staking_program_id == "no_staking"
+        assert store_calls == [True], "service.store() must be called once"
+
+    def test_staking_reset_store_oserror_raises_unmigratable(
+        self, orch: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If `service.store()` fails after on-chain ops have committed,
+        a `_Unmigratable` is raised so the filesystem copy is skipped and
+        the user sees the disk-write failure in the summary — instead of
+        silently propagating an OSError that aborts the whole batch."""
+        m, FakeChain, FakeOnChainState = orch
+        _, manager = self._setup_manager(FakeChain, FakeOnChainState)
+
+        def boom() -> None:
+            raise OSError("disk full")
+
+        # Override the auto-built svc_obj's store with a failing variant.
+        manager.load("anything").store = boom  # type: ignore[misc]
+
+        qs_app = types.SimpleNamespace(service_manager=lambda: manager)
+        monkeypatch.setattr(m, "stop_via_middleware",
+                            lambda operate, config_path: None)
+        monkeypatch.setattr(m, "force_remove_known_containers", lambda: [])
+        monkeypatch.setattr(m, "service_nft_owner", lambda **kw: "0xpl")
+        monkeypatch.setattr(m, "safe_owners", lambda **kw: ["0xpl"])
+
+        ref = _fake_service("sc-aaa", name="A", agent_addresses=[], path=tmp_path)
+        with pytest.raises(m._Unmigratable) as ei:
+            m._migrate_one_service(
+                svc=ref, qs_app=qs_app,
+                qs_wallet=types.SimpleNamespace(
+                    crypto="CR", address="0xqs_eoa",
+                    ledger_api=lambda **kw: object(),
+                    safes={FakeChain.GNOSIS: "0xqs"},
+                ),
+                pearl_wallet=types.SimpleNamespace(
+                    safes={FakeChain.GNOSIS: "0xpl"},
+                ),
+                config_path=None,
+            )
+        assert ei.value.chain is None
+        assert "staking_program_id" in ei.value.reason
+        assert "disk full" in ei.value.reason
 
 
 class TestPearlSafeFundsWait:

--- a/tests/test_staking_service.py
+++ b/tests/test_staking_service.py
@@ -104,8 +104,8 @@ class StakingBaseTestService(BaseTestService):
     def get_staking_config_settings(self) -> dict:
         """Get config specific settings with updated staking handler."""
         settings = get_config_specific_settings(self.config_path)
-        if r"Enter your choice" in settings["prompts"]:
-            settings["prompts"].pop(r"Enter your choice", None)
+        base_choice_key = r"Enter your choice\s*\(\s*\d+\s*-\s*\d+\s*\)\s*:\s*$"
+        settings["prompts"].pop(base_choice_key, None)
         settings["prompts"][r"Enter your choice \(1 - \d+\):"] = self.handle_staking_choice
         return settings
     


### PR DESCRIPTION
## Summary

Quickstart is being discontinued **2026-05-04**. This adds a single-command migration path that preserves the on-chain service NFT, agent EOAs, service Safe, and remaining funds when moving from quickstart to the Pearl Electron app.

Two auto-detected modes:

- **Mode A (fresh copy)** — `~/.operate` doesn't exist yet. Stop the deployment, fix root-owned files, copy `.operate/` into home, rename source for rollback.
- **Mode B (merge)** — `~/.operate` already has a Pearl master wallet. Align passwords, then per service per chain: stop deployment, terminate on-chain, transfer ServiceRegistry NFT (`transferFrom` qs Safe → Pearl Safe), swap service-Safe owner from qs to Pearl, copy service dir + agent keys; then drain master Safe + EOA into Pearl on every chain (skipped when the user picked only some of the quickstart's services so the unselected ones keep their gas). Idempotent — each step probes source-of-truth before acting so re-runs after a crash resume from the first incomplete step.

Usage: `./migrate_to_pearl.sh [path/to/config.json]` (same arg shape as `./run_service.sh`).

## How it works

### Top-level flow

```mermaid
flowchart TD
    Start([./migrate_to_pearl.sh]) --> Disc[Discovery: detect.py<br/>scan ./.operate and ~/.operate]
    Disc --> Mode{Pearl ~/.operate<br/>exists?}
    Mode -->|No| ModeA[Mode A: fresh copy]
    Mode -->|Yes, has master wallet| ModeB[Mode B: merge]

    ModeA --> ASto[force_remove_known_containers]
    ASto --> AChown[fix_root_ownership<br/>sudo chown -RP services/]
    AChown --> ACopy[fresh_copy_store<br/>shutil.copytree .operate -> ~/.operate]
    ACopy --> ARename[rename_source_for_rollback<br/>.operate -> .operate.migrated.bak.ts]
    ARename --> Done([Pearl ready])

    ModeB --> BLoad[Load both wallets<br/>qs and Pearl]
    BLoad --> BPwd{passwords<br/>match?}
    BPwd -->|No| BAlign[align_quickstart_password<br/>snapshot + re-encrypt qs keys with Pearl pw]
    BPwd -->|Yes| BChown
    BAlign --> BChown[fix_root_ownership]
    BChown --> BLoop[For each service x chain]
    BLoop --> BSvc[Per-service migration<br/>see sequence diagram]
    BSvc --> BLoop
    BLoop -->|all services done| BSubset{subset of<br/>services<br/>migrated?}
    BSubset -->|No, full set| BDrain[drain master Safe + EOA into Pearl<br/>per chain]
    BSubset -->|Yes, subset| BSkipDrain[skip drain — unselected services<br/>still need shared master gas]
    BSkipDrain --> BKeep
    BDrain --> BRename{outcome<br/>complete?}
    BRename -->|Yes| BMv[rename_source_for_rollback]
    BRename -->|No| BKeep[Source kept in place<br/>so user can re-run resumed]
    BMv --> Done
    BKeep --> Done
```

### Mode B — per-service per-chain migration

Each service-chain pair walks four on-chain steps and one filesystem step. Every step is idempotent: it reads source-of-truth before mutating, and skips if already in the target state. A re-run after a crash resumes from the first incomplete step.

```mermaid
sequenceDiagram
    autonumber
    participant U as User<br/>(master EOA)
    participant QS as qs master Safe
    participant SR as ServiceRegistry
    participant SS as service multisig
    participant PE as Pearl master Safe
    participant FS as Filesystem

    Note over U,FS: _migrate_one_service
    Note over SS: _step_terminate

    U->>QS: terminate_service_on_chain_from_safe
    QS->>SR: terminate (and unstake if applicable)
    QS->>SS: swap agents → qs master Safe<br/>(operate's internal swap, current owners are EOAs)
    Note over SS: now owned by qs master Safe

    Note over U,FS: _step_transfer_nft

    U->>QS: send_safe_txs(transferFrom calldata)
    QS->>SR: transferFrom(qs, pearl, tokenId)
    QS-->>U: tx_hash
    U->>SR: ownerOf(tokenId) [retried up to 3×]
    SR-->>U: pearl ✓

    Note over U,FS: _step_swap_service_safe_owner<br/>see Safe-A-controlling-Safe-B diagram

    U->>QS: send_safe_txs(approveHash calldata)
    QS->>SS: approveHash(inner_tx_hash)
    U->>QS: send_safe_txs(execTransaction calldata)
    QS->>SS: execTransaction(swapOwner args, approved-hash sig)
    SS->>SS: self-call swapOwner(prev, qs, pearl)
    Note over SS: now owned by Pearl Safe
    U->>SS: getOwners() [retried up to 3×]
    SS-->>U: [pearl] ✓

    Note over U,FS: merge_service (filesystem)

    U->>FS: shutil.copytree(qs/services/sc-X, pearl/services/sc-X)
    U->>FS: shutil.copy2(qs/keys/<addr>, pearl/keys/<addr>)<br/>verbatim — passwords already aligned
```

### Why `swapOwner` needs the Safe-A-controlling-Safe-B pattern

After `terminate`, the service multisig's only owner is the **qs master Safe** — a contract, not an EOA. Gnosis Safe's `swapOwner` has the `authorized` modifier, so it can ONLY be invoked through the service Safe's own `execTransaction`. The qs master Safe (which IS an owner) authorizes the swap via the on-chain `approveHash` path.

```mermaid
sequenceDiagram
    autonumber
    participant E as master EOA<br/>(owner of qs Safe)
    participant QS as qs master Safe
    participant SS as service Safe<br/>(owner = qs Safe)

    Note over E,SS: Step 1 — register pre-approval

    E->>QS: execTransaction(<br/>to=SS, data=approveHash(h))
    QS->>SS: approveHash(inner_tx_hash)
    Note over SS: approvedHashes[QS][h] = 1

    Note over E,SS: Step 2 — execute the swap

    E->>QS: execTransaction(<br/>to=SS, data=execTransaction(swapOwner args,<br/>signatures=packed_approved_hash(QS)))
    QS->>SS: execTransaction(swapOwner args, sig)
    SS->>SS: validate sig: signer=QS,<br/>approvedHashes[QS][h] == 1 ✓
    SS->>SS: self-call: swapOwner(prev, qs, pearl)
    Note over SS: msg.sender == address(this) ✓<br/>authorized check passes<br/>owners updated
```

### Mode B — password alignment

When qs and Pearl were initialised with different master passwords, agent keys would otherwise be copied verbatim and Pearl's keys manager (using Pearl's password) would fail to decrypt them at deploy time with `DecryptError`. Rather than carrying two passwords through `merge_service`, we re-encrypt the qs store IN PLACE before the merge.

```mermaid
flowchart TD
    Detect{qs_app.password<br/>== pearl_app.password?} -->|Yes| Skip[no-op]
    Detect -->|No| Prompt[print ALIGNING QUICKSTART PASSWORD<br/>section; ask user to confirm]
    Prompt -->|y| Snap[Snapshot wallets/+keys/<br/>to .pre-align.&lt;ts&gt;/]
    Prompt -->|n| Abort[fatal: nothing on-chain has changed]

    Snap --> Master[qs_wallet.update_password Pearl_pw<br/>operate's MasterWallet.update_password<br/>writes new keyfile]
    Master --> Walk[For each key in keys/]
    Walk --> Skip2{suffix<br/>.tmp or .bak?}
    Skip2 -->|Yes| Walk
    Skip2 -->|No| Reenc[_reencrypt_agent_key<br/>decrypt with old, encrypt with new<br/>atomic .tmp + replace]
    Reenc --> Walk
    Walk -->|all keys done| Plumb[qs_app.password = Pearl_pw<br/>keys_manager.password = Pearl_pw]
    Plumb --> OK([proceed to merge])

    Master -. on any failure .-> Recover[warn: recovery command<br/>rm -rf wallets keys + mv snapshot back]
    Walk -. on any failure .-> Recover
```

The snapshot is never auto-deleted — on success the user may remove `.pre-align.<ts>/` once Pearl has launched; on failure it is the only recovery artifact.

## Design highlights

- **`MigrationOutcome`** aggregate (`unmigratable`, `drain_failures`, `subset_selected`) gates drain + source-rename so partial-failure state — and intentional partial coverage — is preserved on disk for re-runs.
- **Subset-drain protection** — when the user picks only some services (`--quickstart-config <path>` or single-pick from the multi-service prompt), `_run_mode_b` receives `subset_selected=True` and skips the master-Safe / EOA drain. Otherwise the shared master wallet would be drained out from under the unselected services, leaving them without gas. Source `.operate/` is also kept in place so a follow-up run can pick the rest up; the summary and final-prompt branches print dedicated messages (no "different machine?" question) so the user knows exactly what happened.
- **Stake-program reset to `no_staking`** (`reset_services_staking_to_no_staking`) — both modes pin the migrated service config's `staking_program_id = no_staking` via `OperateStore.services()` + `Service.store()` (atomic write through middleware code paths). Pearl would otherwise re-apply quickstart's staking template and try to re-stake on a service that's already been unstaked on-chain.
- **Funds-wait + retry on signing sites** (`_retry_on_funds_shortage`) — wraps `_step_terminate`, `_step_transfer_nft`, `_step_swap_service_safe_owner`, and both `pearl_wallet.create_safe` calls. Mirrors middleware's `ask_funds_in_address` UX: print the EOA address, poll balance every 5s, retry once funds arrive. Drain is intentionally NOT wrapped — middleware's drain swallows per-asset transfer errors internally and continues, so the wait would never engage. The poll loop tolerates transient RPC outages.
- **`_PROGRAMMING_BUGS` policy** via `_reraise_if_programming_bug(exc)` helper applied at every `except Exception` site. `TypeError`/`AttributeError`/`NameError`/`ImportError` surface as real tracebacks; `KeyError`/`LookupError` from missing chain metadata become per-service `_Unmigratable` so one bad chain doesn't crash the multi-service batch.
- **Container-cleanup safety**: `force_remove_known_containers` propagates `TimeoutExpired` and converts non-zero `docker rm -f` exit to `RuntimeError` (daemon refused, `/var/run/docker.sock` perms); `docker_quickstart_containers` raises on non-zero `docker ps` exit. Both modes share `_ensure_containers_stopped(on_failure=...)` which re-probes after cleanup (Mode A → `fatal`, Mode B → `_Unmigratable` so per-service aggregation still works) so a still-live deployment is never raced. Detection uses **substring matching** on `QUICKSTART_CONTAINER_FRAGMENTS` (`abci0`, `node0`, `_abci_0`, `_tm_0`) so per-service container names the middleware actually emits (`trader_abci_0`, `meme_factory_tm_0`, ...) are caught — exact-set matching had silently skipped them. `run_service.sh` updated to converge on the same fragments.
- **Password alignment with snapshot recovery** (`align_quickstart_password`) — Mode B re-encrypts qs's master keyfile + every agent key with Pearl's password BEFORE merging, so Pearl's keys manager can decrypt at deploy time. Snapshot of `wallets/+keys/` is taken before any mutation; the failure message includes the concrete `mv` command to recover.
- **`user.json` ↔ wallet keyfile hash alignment** (`align_user_account_to_wallet`) — middleware's `ask_password_if_needed` (called inside `stop_service` and various other flows) validates against `user.json` and unconditionally overwrites `operate.password`, clobbering the wallet-validated password we already loaded. On installs where the two hashes diverge (legacy create-then-import, manual rotation), every subsequent signing op then `DecryptError`s — flattened by `OnChainHelper.load_crypto` to a generic "Cannot load private key" message. We rewrite `user.json`'s argon2 hash to the wallet-validated password at the end of `_load_wallet` (and again after `align_quickstart_password`) so middleware's password resolver returns the wallet password we control.
- **Safe-A-controlling-Safe-B swap pattern** (`swap_service_safe_owner`) — `swapOwner` has the `authorized` modifier requiring `msg.sender == address(this)`, so it MUST go through the service Safe's own `execTransaction`. We use the qs master Safe's pre-approved-hash signature (mirrors operate's `EthSafeTxBuilder.get_safe_b_native_transfer_messages`).
- **Post-condition verification + `PostConditionUnknown`** — both on-chain ops re-read state after `send_safe_txs` and distinguish "inner reverted" (`RuntimeError`) from "verification read died" (`PostConditionUnknown`). The latter surfaces verbatim to the user with explicit "DO NOT re-run blindly — verify on a block explorer" guidance, so a transient RPC hiccup post-mining doesn't push the user into a re-run that double-submits.
- **Filesystem-copy failures after on-chain commit** (incl. missing agent keys via `MissingAgentKey`) aggregate into `unmigratable` with an on-chain-already-committed remediation message so the user is told exactly what to copy by hand.
- **Root-owned file safety** (`fix_root_ownership`) — Docker leaves root-owned files under `persistent_data/` AND `deployment/nodes/node0/{config,data}/`. We unconditionally `sudo -n chown -RP` every service dir whose resolved path stays inside the store root (rglob-based detection is unreliable on Python 3.14 against unreadable subtrees). Failure includes an audit trail of dirs already mutated.
- **`transferFrom` not `safeTransferFrom`** — Safe-to-Safe move; bypasses the `onERC721Received` requirement that would silently revert on Safes without `CompatibilityFallbackHandler`.

## Reuse

Builds on `olas-operate-middleware` primitives. Reused: `Service.load`, `MasterWalletManager`, `MasterWallet.update_password`, `MasterWallet.drain`, `terminate_service_on_chain_from_safe`, `gnosis.send_safe_txs`, `gnosis.get_prev_owner`, `gnosis.get_owners`, `services.protocol.get_packed_signature_for_approved_hash`, `OPERATE`/`SERVICES_DIR`/`KEYS_DIR`/`WALLETS_DIR` constants. Custom pieces: NFT `transferFrom` ABI encode in `transfer.py`, the Safe-A-controlling-Safe-B `approveHash + execTransaction` swap composition (no single middleware helper exists for swap-when-current-owner-is-itself-a-Safe), the qs-side password alignment, and the post-condition retry helper.

## Test plan

- [x] **370 unit tests** at 100% line coverage (gate enforced via `--cov-fail-under=100`).
- [x] **E2E test** against real Tenderly forks: 4 services across 2 quickstarts (different passwords) merged into one Pearl, every service starts post-migration via `deploy_on_chain_from_safe`. ~30 min.
- [x] **Tenderly isolation test** for `swap_service_safe_owner`: deploys two fresh Safes (outer Safe owns inner Safe), runs the swap, asserts `getOwners` returns `[new_owner]`. Validates the approveHash + execTransaction path end-to-end without docker/pexpect.
- [x] **CI integration** — new `e2e-test-migrate-to-pearl` job with paths-filter (only runs when migration files or middleware version change).
- [ ] Manual smoke test on a real `gnosisscan` predict_trader deployment (Mode B path) — recommended before merging.
- [ ] Manual smoke test of resume-after-partial-failure (kill mid-Mode-B, re-run, verify resume from first incomplete step).
- [ ] Manual smoke test of password mismatch (Mode B with qs and Pearl initialised under different passwords).

## Out of scope

- Bundled cross-machine migration (the final prompt tells the user how to `scp ~/.operate/`).
- Recovering services with lost master Safe keys (pointer to the existing `fund_recovery_manager.py` instead).
- Receipt-level parsing of Safe `ExecutionSuccess` / `ExecutionFailure` events (would tighten `PostConditionUnknown` further; current direct state-read post-condition is adequate).

## Review history

11 rounds of multi-agent review (`/ecc:review-pr`); all critical and important findings addressed. Round-2 critical fixes: `align_quickstart_password` for Mode B password mismatch (was failing test_04 with `DecryptError`). Round-3 critical fixes: post-condition reads after `send_safe_txs` (Gnosis Safe doesn't bubble inner-call failures; outer status=1 was being mistaken for inner success). Round-4 fixes: `PostConditionUnknown` exception type to distinguish RPC failure from real revert; caller wrappers `raise ... from exc` to preserve traceback chain; `_RPC_EXCEPTION_TYPES` cached at module load and includes `asyncio.TimeoutError` for Python 3.10. Remaining advisory items (snapshot also covering non-Ethereum ledgers, snapshot copytree itself unguarded, approveHash step lacking its own post-condition) intentionally deferred — diminishing returns vs the script's 2-month shelf life.

