### PR TITLE
ci: add `All checks passed` aggregate gate

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -390,3 +390,25 @@ jobs:
       with:
         name: unit-test-coverage-xml-${{ matrix.python-version }}
         path: coverage-unit.xml
+
+  all-checks-passed:
+    # Single aggregate gate referenced by branch protection. When adding or
+    # removing a mandatory job, update the `needs:` list here instead of
+    # editing branch protection contexts.
+    name: All checks passed
+    if: always()
+    runs-on: ubuntu-24.04
+    needs:
+      - setup
+      - e2e-test-run-service
+      - e2e-test-staking
+      - changes
+      - e2e-test-migrate-to-pearl
+      - unit-tests
+    steps:
+      - name: Verify all dependencies succeeded or were skipped
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a single `all-checks-passed` meta job (rendered check name: `All checks passed`) that depends on every mandatory job in this workflow.
- Required by `main` branch protection as the single status check context, so future job additions/removals only need a `needs:` edit here instead of a branch-protection change.
- `if: always()` + a `contains(needs.*.result, 'failure'/'cancelled')` check lets conditionally-skipped jobs (e.g. `e2e-test-migrate-to-pearl`) pass through cleanly while still failing the gate on any real failure or cancel.

## Test plan
- [ ] CI runs all jobs and the new `All checks passed` job reports success on this PR.
- [ ] Verify in branch protection settings on `main` that `All checks passed` is the only required context.
- [ ] After merge, confirm `main` shows the `All checks passed` check on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)