### PR TITLE
chore(deps): bump olas-operate-middleware to 0.15.21 to patch starlette CVE

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -235,6 +235,18 @@ files = [
 jsonalias = "0.1.1"
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
+    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -1750,19 +1762,20 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.117.1"
+version = "0.120.4"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "fastapi-0.117.1-py3-none-any.whl", hash = "sha256:33c51a0d21cab2b9722d4e56dbb9316f3687155be6b276191790d8da03507552"},
-    {file = "fastapi-0.117.1.tar.gz", hash = "sha256:fb2d42082d22b185f904ca0ecad2e195b851030bd6c5e4c032d1c981240c631a"},
+    {file = "fastapi-0.120.4-py3-none-any.whl", hash = "sha256:9bdf192308676480d3593e10fd05094e56d6fdc7d9283db26053d8104d5f82a0"},
+    {file = "fastapi-0.120.4.tar.gz", hash = "sha256:2d856bc847893ca4d77896d4504ffdec0fb04312b705065fca9104428eca3868"},
 ]
 
 [package.dependencies]
+annotated-doc = ">=0.0.2"
 pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
-starlette = ">=0.40.0,<0.49.0"
+starlette = ">=0.40.0,<0.50.0"
 typing-extensions = ">=4.8.0"
 
 [package.extras]
@@ -2612,14 +2625,14 @@ nicer-shell = ["ipython"]
 
 [[package]]
 name = "olas-operate-middleware"
-version = "0.15.20"
+version = "0.15.21"
 description = ""
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "olas_operate_middleware-0.15.20-py3-none-any.whl", hash = "sha256:f1ce9fa7f387abb1e1b98f9655d6bb04694788549ded42c0d430bba7901e4710"},
-    {file = "olas_operate_middleware-0.15.20.tar.gz", hash = "sha256:a52e872b1b8ed1099bda06b68957f5880a734ce6f0c46a9667fa354d62d2cacf"},
+    {file = "olas_operate_middleware-0.15.21-py3-none-any.whl", hash = "sha256:3004aec9f7eabba0aafe8884133df1e53c0bc9513fb20b9a1d17c3ccd49e6ea8"},
+    {file = "olas_operate_middleware-0.15.21.tar.gz", hash = "sha256:f0ed6fbcdb87b9e20c43b4fcc8daec1b70cb8bb0d432d243d0a3c390762f355a"},
 ]
 
 [package.dependencies]
@@ -2629,7 +2642,7 @@ clea = "0.1.0rc4"
 cryptography = ">=46.0.7,<47.0.0"
 cytoolz = ">=1.0.0,<1.2.0"
 deepdiff = ">=8.6.2,<9.0.0"
-fastapi = ">=0.117,<0.118"
+fastapi = ">=0.120,<0.121"
 flask = ">=3.0,<4.0"
 halo = "0.0.31"
 multiaddr = "0.0.9"
@@ -4138,14 +4151,14 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "0.49.3"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659"},
-    {file = "starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46"},
+    {file = "starlette-0.49.3-py3-none-any.whl", hash = "sha256:b579b99715fdc2980cf88c8ec96d3bf1ce16f5a8051a7c2b84ef9b1cdecaea2f"},
+    {file = "starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284"},
 ]
 
 [package.dependencies]
@@ -4677,4 +4690,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "c9a88e37c05fbb5c1258c26fea6acbe202798e6a7ae29fe1acf7fb2a58accdbd"
+content-hash = "ae778df079b10f2a9e59541ba4414322f9f42b28cd1a77afdb946633e4dcf76f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = []
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.15"
-olas-operate-middleware = "0.15.20"
+olas-operate-middleware = "0.15.21"
 tqdm = "4.67.3"
 python-dotenv = "1.2.2"
 gql = {version = "3.5.0", extras = ["requests"]}


### PR DESCRIPTION
## Summary

- Bumps `olas-operate-middleware` from `0.15.20` to `0.15.21`.
- Resolves the residual Dependabot alert left after #170: **[#28 — starlette GHSA-7f5h-v6xp-fcq8](https://github.com/valory-xyz/quickstart/security/dependabot/28)** (high; O(n²) DoS via `Range` header merging in `starlette.responses.FileResponse`).

## Dependency chain

`olas-operate-middleware 0.15.21` lifts its fastapi cap (`^0.117` → `^0.120`), which pulls in:

| Package | Before | After |
|---|---|---|
| fastapi | 0.117.1 | 0.120.4 |
| starlette | 0.48.0 (vulnerable) | 0.49.3 (patched, ≥0.49.1) |
| annotated-doc | — | 0.0.4 (new transitive of fastapi 0.120) |

starlette `0.49.1+` patches GHSA-7f5h-v6xp-fcq8 (vulnerable range `>=0.39.0,<=0.49.0`).

No other constraint changes in middleware 0.15.21 — only the fastapi cap moved. Middleware 0.15.21 release notes: https://github.com/valory-xyz/olas-operate-middleware/releases/tag/v0.15.21

## Test plan

- [ ] CI: unit-tests across 3.10–3.14
- [ ] CI: e2e-test-staking
- [ ] CI: e2e-test-run-service (agents.fun, optimus, predict_trader)
- [ ] CI: e2e-test-migrate-to-pearl (canary for middleware-API surface)
- [ ] Confirm Dependabot alert #28 auto-closes once merged to `main`